### PR TITLE
change MatrixAffine2f to mat3

### DIFF
--- a/include/SvgRenderer.hpp
+++ b/include/SvgRenderer.hpp
@@ -10,7 +10,7 @@ class Context;
 class SvgRenderer : public svg::Renderer {
   Context &mCtx; // TODO(ryan): This should probably be a managed pointer..
 
-  std::vector<MatrixAffine2f> mMatrixStack;
+  std::vector<mat3> mMatrixStack;
   std::vector<svg::Paint> mFillStack, mStrokeStack;
   std::vector<float> mFillOpacityStack, mStrokeOpacityStack;
   std::vector<float> mStrokeWidthStack;
@@ -36,7 +36,7 @@ public:
   void drawImage(const svg::Image &image) override {}
   void drawTextSpan(const svg::TextSpan &span) override {}
 
-  void pushMatrix(const MatrixAffine2f &m) override;
+  void pushMatrix(const mat3 &m) override;
   void popMatrix() override;
   void pushStyle(const svg::Style &style) override {};
   void popStyle(const svg::Style &style) override {};

--- a/include/ci_nanovg.hpp
+++ b/include/ci_nanovg.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "cinder/MatrixAffine2.h"
+#include "cinder/Matrix.h"
 #include "cinder/Vector.h"
 #include "cinder/Rect.h"
 #include "cinder/Color.h"
@@ -76,8 +76,8 @@ public:
   // Transform //
 
   void resetTransform();
-  void transform(const MatrixAffine2f &mtx);
-  void setTransform(const MatrixAffine2f &mtx);
+  void transform(const mat3 &mtx);
+  void setTransform(const mat3 &mtx);
   void translate(float x, float y);
   void translate(const vec2 &translation);
   void rotate(float angle);
@@ -86,7 +86,7 @@ public:
   void scale(float x, float y);
   void scale(const vec2 &s);
 
-  MatrixAffine2f currentTransform();
+  mat3 currentTransform();
 
   // Paints //
 

--- a/src/SvgRenderer.cpp
+++ b/src/SvgRenderer.cpp
@@ -6,7 +6,7 @@
 namespace cinder { namespace nvg {
 
 SvgRenderer::SvgRenderer(Context &ctx) : mCtx{ ctx } {
-  mMatrixStack.emplace_back(MatrixAffine2f::identity());
+  mMatrixStack.emplace_back(mat3(1));
   mFillStack.push_back(svg::Paint(Color::black()));
   mStrokeStack.push_back(svg::Paint());
   mFillOpacityStack.push_back(1.0f);
@@ -126,8 +126,8 @@ void SvgRenderer::drawEllipse(const svg::Ellipse &ellipse) {
 }
 
 
-void SvgRenderer::pushMatrix(const MatrixAffine2f &top) {
-  MatrixAffine2f m = mMatrixStack.back() * top;
+void SvgRenderer::pushMatrix(const mat3 &top) {
+  mat3 m = mMatrixStack.back() * top;
   mMatrixStack.emplace_back(m);
 }
 void SvgRenderer::popMatrix() {
@@ -169,11 +169,8 @@ void SvgRenderer::popStrokeWidth() {
   mStrokeWidthStack.pop_back();
 }
 
-void SvgRenderer::pushFillRule(svg::FillRule rule) {
-  // Fill rules other than even-odd are not supported by NanoVG.
-}
-void SvgRenderer::popFillRule() {
-}
+void SvgRenderer::pushFillRule(svg::FillRule) {}
+void SvgRenderer::popFillRule() {}
 
 void SvgRenderer::pushLineCap(svg::LineCap lineCap) {
   int cap = lineCap == svg::LINE_CAP_ROUND  ? NVG_ROUND :

--- a/src/ci_nanovg.cpp
+++ b/src/ci_nanovg.cpp
@@ -160,10 +160,10 @@ void Context::lineJoin(int join) {
 void Context::resetTransform() {
   nvgResetTransform(get());
 }
-void Context::transform(const MatrixAffine2f &mtx) {
-  nvgTransform(get(), mtx[0], mtx[1], mtx[2], mtx[3], mtx[4], mtx[5]);
+void Context::transform(const mat3 &mtx) {
+  nvgTransform(get(), mtx[0][0], mtx[0][1], mtx[1][0], mtx[1][1], mtx[2][0], mtx[2][1]);
 }
-void Context::setTransform(const MatrixAffine2f &mtx) {
+void Context::setTransform(const mat3 &mtx) {
   resetTransform();
   transform(mtx);
 }
@@ -189,9 +189,9 @@ void Context::scale(const vec2 &s) {
   scale(s.x, s.y);
 }
 
-MatrixAffine2f Context::currentTransform() {
-  MatrixAffine2f xform;
-  nvgCurrentTransform(get(), &xform[0]);
+mat3 Context::currentTransform() {
+  mat3 xform;
+  nvgCurrentTransform(get(), &xform[0][0]);
   return xform;
 }
 


### PR DESCRIPTION
the glNext branch changed MatrixAffine2f to mat3 why I replaced those occurrences in the NanoVG-Block

furthermore MatrixAffine2f::identity() turned into mat3(1)
(see: https://forum.libcinder.org/topic/gl-begin-next, third post)