### PR TITLE
Update Xcode projects to compile on master

### DIFF
--- a/samples/HelloSvg/xcode/HelloSvg.xcodeproj/project.pbxproj
+++ b/samples/HelloSvg/xcode/HelloSvg.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,26 +14,16 @@
 		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		1F33D436FCD34252A31428FF /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 331837629E624870A70D5618 /* SvgRenderer.cpp */; };
+		2AEA42D6779745D7B455B282 /* HelloSvgApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E893BA0CD6E349BEB24B2F19 /* HelloSvgApp.cpp */; };
+		4137796B28C84C1EA54A193A /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E8D4C5917B34732877D3F13 /* ci_nanovg_gl.cpp */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
-		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-		1F33D436FCD34252A31428FF /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 331837629E624870A70D5618 /* SvgRenderer.cpp */; };
-		4137796B28C84C1EA54A193A /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9E8D4C5917B34732877D3F13 /* ci_nanovg_gl.cpp */; };
 		7CB329C3BBF04E688CACB724 /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E57BC86E7B784D03A834767E /* ci_nanovg.cpp */; };
-		C3BF2AAB40F24D1EA8463CB9 /* SvgRenderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0BB955051CF6429A8640234E /* SvgRenderer.hpp */; };
-		4F081311544B444EA1DC3568 /* ci_nanovg_gl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C911656698F9498780CF4AC6 /* ci_nanovg_gl.hpp */; };
-		E4BE965E515340A6AE2CFD5F /* ci_nanovg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 53E8F7E48ABB4E5B81FF0C37 /* ci_nanovg.hpp */; };
-		F01D65599DE1442E8C5D626A /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F1A3CDD2F70442E80033851 /* nanovg.c */; };
-		536933BA33274089BBF11789 /* stb_truetype.h in Headers */ = {isa = PBXBuildFile; fileRef = C2252C80497D43F595E9BEB4 /* stb_truetype.h */; };
-		9E4E47A345CA4DDA947A28A8 /* stb_image.h in Headers */ = {isa = PBXBuildFile; fileRef = E82CA687F9AF4C989FF4F349 /* stb_image.h */; };
-		B906A56850804C9FBE2711E6 /* nanovg_gl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3525D3A48F844C82A582DDF5 /* nanovg_gl_utils.h */; };
-		34F7847811894624BCD22379 /* nanovg_gl.h in Headers */ = {isa = PBXBuildFile; fileRef = 73BA78BDD7D74BC286FBA45D /* nanovg_gl.h */; };
-		641EA9BBB8D447D4812F8E27 /* nanovg.h in Headers */ = {isa = PBXBuildFile; fileRef = 95126EC617D84BE5BFA40DE7 /* nanovg.h */; };
-		DD4B108EDCA64AB39D4D5CFE /* fontstash.h in Headers */ = {isa = PBXBuildFile; fileRef = CC8030FA212D495E94314F56 /* fontstash.h */; };
-		54A93B6494A045D2BC5DF5A4 /* HelloSvg_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 92811619F5C04F7EAB04FE86 /* HelloSvg_Prefix.pch */; };
+		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		9FE45718D0F04FC9A8BCD5EC /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = 2E8B506239564ACC91FD271A /* CinderApp.icns */; };
-		C39024B5CB814831A5B749F5 /* Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = C87718644C1A42EDB11EDEBC /* Resources.h */; };
-		2AEA42D6779745D7B455B282 /* HelloSvgApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E893BA0CD6E349BEB24B2F19 /* HelloSvgApp.cpp */; };
+		D86349FE1B3923B600B5C3D9 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D86349FD1B3923B600B5C3D9 /* IOKit.framework */; };
+		F01D65599DE1442E8C5D626A /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F1A3CDD2F70442E80033851 /* nanovg.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,30 +34,31 @@
 		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		00B784B10FF439BC000DE1D7 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		0BB955051CF6429A8640234E /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = SvgRenderer.hpp; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		1F1A3CDD2F70442E80033851 /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = nanovg.c; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		2E8B506239564ACC91FD271A /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; };
+		331837629E624870A70D5618 /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = SvgRenderer.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; };
+		3525D3A48F844C82A582DDF5 /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl_utils.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; };
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
+		53E8F7E48ABB4E5B81FF0C37 /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg.hpp; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; };
+		73BA78BDD7D74BC286FBA45D /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* HelloSvg.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloSvg.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		E893BA0CD6E349BEB24B2F19 /* HelloSvgApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../src/HelloSvgApp.cpp; sourceTree = "<group>"; name = HelloSvgApp.cpp; };
-		C87718644C1A42EDB11EDEBC /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../include/Resources.h; sourceTree = "<group>"; name = Resources.h; };
-		2E8B506239564ACC91FD271A /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
-		A7B22C3962C6430693BB98EA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		92811619F5C04F7EAB04FE86 /* HelloSvg_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = HelloSvg_Prefix.pch; sourceTree = "<group>"; name = HelloSvg_Prefix.pch; };
-		CC8030FA212D495E94314F56 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; name = fontstash.h; };
-		95126EC617D84BE5BFA40DE7 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; name = nanovg.h; };
-		73BA78BDD7D74BC286FBA45D /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; name = nanovg_gl.h; };
-		3525D3A48F844C82A582DDF5 /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; name = nanovg_gl_utils.h; };
-		E82CA687F9AF4C989FF4F349 /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; name = stb_image.h; };
-		C2252C80497D43F595E9BEB4 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; name = stb_truetype.h; };
-		1F1A3CDD2F70442E80033851 /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; name = nanovg.c; };
-		53E8F7E48ABB4E5B81FF0C37 /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; name = ci_nanovg.hpp; };
-		C911656698F9498780CF4AC6 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; name = ci_nanovg_gl.hpp; };
-		0BB955051CF6429A8640234E /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; name = SvgRenderer.hpp; };
-		E57BC86E7B784D03A834767E /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; name = ci_nanovg.cpp; };
-		9E8D4C5917B34732877D3F13 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; name = ci_nanovg_gl.cpp; };
-		331837629E624870A70D5618 /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; name = SvgRenderer.cpp; };
+		92811619F5C04F7EAB04FE86 /* HelloSvg_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = HelloSvg_Prefix.pch; sourceTree = "<group>"; };
+		95126EC617D84BE5BFA40DE7 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; };
+		9E8D4C5917B34732877D3F13 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg_gl.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; };
+		A7B22C3962C6430693BB98EA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C2252C80497D43F595E9BEB4 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; };
+		C87718644C1A42EDB11EDEBC /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
+		C911656698F9498780CF4AC6 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg_gl.hpp; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; };
+		CC8030FA212D495E94314F56 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fontstash.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; };
+		D86349FD1B3923B600B5C3D9 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		E57BC86E7B784D03A834767E /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; };
+		E82CA687F9AF4C989FF4F349 /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_image.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; };
+		E893BA0CD6E349BEB24B2F19 /* HelloSvgApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = HelloSvgApp.cpp; path = ../src/HelloSvgApp.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +66,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D86349FE1B3923B600B5C3D9 /* IOKit.framework in Frameworks */,
 				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
 				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
@@ -91,6 +83,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		00C66E583EB141ADBADD4A44 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				E57BC86E7B784D03A834767E /* ci_nanovg.cpp */,
+				9E8D4C5917B34732877D3F13 /* ci_nanovg_gl.cpp */,
+				331837629E624870A70D5618 /* SvgRenderer.cpp */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+				45EBAAA5F269451482F5A3DF /* NanoVG */,
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
 		080E96DDFE201D6D7F000001 /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -102,6 +112,7 @@
 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D86349FD1B3923B600B5C3D9 /* IOKit.framework */,
 				006D720219952D00008149E2 /* AVFoundation.framework */,
 				006D720319952D00008149E2 /* CoreMedia.framework */,
 				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
@@ -146,74 +157,6 @@
 			name = HelloSvg;
 			sourceTree = "<group>";
 		};
-		C833720E66AD451A86606319 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				CC8030FA212D495E94314F56 /* fontstash.h */,
-				95126EC617D84BE5BFA40DE7 /* nanovg.h */,
-				73BA78BDD7D74BC286FBA45D /* nanovg_gl.h */,
-				3525D3A48F844C82A582DDF5 /* nanovg_gl_utils.h */,
-				E82CA687F9AF4C989FF4F349 /* stb_image.h */,
-				C2252C80497D43F595E9BEB4 /* stb_truetype.h */,
-				1F1A3CDD2F70442E80033851 /* nanovg.c */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		E5EDE08E2AB64BAD8BE79344 /* nanovg */ = {
-			isa = PBXGroup;
-			children = (
-				C833720E66AD451A86606319 /* src */,
-			);
-			name = nanovg;
-			sourceTree = "<group>";
-		};
-		47C57DA44FAB4BB09F7F3A41 /* deps */ = {
-			isa = PBXGroup;
-			children = (
-				E5EDE08E2AB64BAD8BE79344 /* nanovg */,
-			);
-			name = deps;
-			sourceTree = "<group>";
-		};
-		2A8B9A9FA09A4B8F8440851C /* include */ = {
-			isa = PBXGroup;
-			children = (
-				53E8F7E48ABB4E5B81FF0C37 /* ci_nanovg.hpp */,
-				C911656698F9498780CF4AC6 /* ci_nanovg_gl.hpp */,
-				0BB955051CF6429A8640234E /* SvgRenderer.hpp */,
-			);
-			name = include;
-			sourceTree = "<group>";
-		};
-		00C66E583EB141ADBADD4A44 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E57BC86E7B784D03A834767E /* ci_nanovg.cpp */,
-				9E8D4C5917B34732877D3F13 /* ci_nanovg_gl.cpp */,
-				331837629E624870A70D5618 /* SvgRenderer.cpp */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		45EBAAA5F269451482F5A3DF /* NanoVG */ = {
-			isa = PBXGroup;
-			children = (
-				47C57DA44FAB4BB09F7F3A41 /* deps */,
-				2A8B9A9FA09A4B8F8440851C /* include */,
-				00C66E583EB141ADBADD4A44 /* src */,
-			);
-			name = NanoVG;
-			sourceTree = "<group>";
-		};
-		01B97315FEAEA392516A2CEA /* Blocks */ = {
-			isa = PBXGroup;
-			children = (
-				45EBAAA5F269451482F5A3DF /* NanoVG */,
-			);
-			name = Blocks;
-			sourceTree = "<group>";
-		};
 		29B97315FDCFA39411CA2CEA /* Headers */ = {
 			isa = PBXGroup;
 			children = (
@@ -239,6 +182,56 @@
 				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		2A8B9A9FA09A4B8F8440851C /* include */ = {
+			isa = PBXGroup;
+			children = (
+				53E8F7E48ABB4E5B81FF0C37 /* ci_nanovg.hpp */,
+				C911656698F9498780CF4AC6 /* ci_nanovg_gl.hpp */,
+				0BB955051CF6429A8640234E /* SvgRenderer.hpp */,
+			);
+			name = include;
+			sourceTree = "<group>";
+		};
+		45EBAAA5F269451482F5A3DF /* NanoVG */ = {
+			isa = PBXGroup;
+			children = (
+				47C57DA44FAB4BB09F7F3A41 /* deps */,
+				2A8B9A9FA09A4B8F8440851C /* include */,
+				00C66E583EB141ADBADD4A44 /* src */,
+			);
+			name = NanoVG;
+			sourceTree = "<group>";
+		};
+		47C57DA44FAB4BB09F7F3A41 /* deps */ = {
+			isa = PBXGroup;
+			children = (
+				E5EDE08E2AB64BAD8BE79344 /* nanovg */,
+			);
+			name = deps;
+			sourceTree = "<group>";
+		};
+		C833720E66AD451A86606319 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				CC8030FA212D495E94314F56 /* fontstash.h */,
+				95126EC617D84BE5BFA40DE7 /* nanovg.h */,
+				73BA78BDD7D74BC286FBA45D /* nanovg_gl.h */,
+				3525D3A48F844C82A582DDF5 /* nanovg_gl_utils.h */,
+				E82CA687F9AF4C989FF4F349 /* stb_image.h */,
+				C2252C80497D43F595E9BEB4 /* stb_truetype.h */,
+				1F1A3CDD2F70442E80033851 /* nanovg.c */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		E5EDE08E2AB64BAD8BE79344 /* nanovg */ = {
+			isa = PBXGroup;
+			children = (
+				C833720E66AD451A86606319 /* src */,
+			);
+			name = nanovg;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -267,6 +260,8 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "HelloSvg" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -317,24 +312,24 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = HelloSvg_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = HelloSvg_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
 				PRODUCT_NAME = HelloSvg;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
@@ -348,54 +343,54 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = HelloSvg_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = HelloSvg_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
 				PRODUCT_NAME = HelloSvg;
 				STRIP_INSTALLED_PRODUCT = YES;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../../..";
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Debug;
 		};
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../../..";
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Release;
 		};

--- a/samples/HelloSvg/xcode_ios/HelloSvg.xcodeproj/project.pbxproj
+++ b/samples/HelloSvg/xcode_ios/HelloSvg.xcodeproj/project.pbxproj
@@ -7,87 +7,64 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00748058165D41390024B57A /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 00748057165D41390024B57A /* assets */; };
 		0087D25512CD809F002CD69F /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0087D25412CD809F002CD69F /* CoreText.framework */; };
+		00A66A361965AC8800B17EB3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A66A351965AC8800B17EB3 /* Accelerate.framework */; };
 		00CFDF6B1138442D0091E310 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091E310 /* CoreGraphics.framework */; };
-		C725E001121DAC8FFFFA18FF /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091FFFF /* ImageIO.framework */; };
-		DDDDE001121DAC8FFFFADDDD /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		28FD15000DC6FC520079059D /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FD14FF0DC6FC520079059D /* OpenGLES.framework */; };
 		28FD15080DC6FC5B0079059D /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FD15070DC6FC5B0079059D /* QuartzCore.framework */; };
-		C725DFFE121DAC7F00FA186B /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02B121B400300192073 /* CoreMedia.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C725E001121DAC8F00FA186B /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C725E000121DAC8F00FA186B /* AVFoundation.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C727C02E121B400300192073 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02D121B400300192073 /* CoreVideo.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C7FB19D6124BC0D70045AFD2 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */; };
-		00A66A361965AC8800B17EB3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A66A351965AC8800B17EB3 /* Accelerate.framework */; };
-		00748058165D41390024B57A /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 00748057165D41390024B57A /* assets */; };
-		809F2549B6EA4CA8B4547FCA /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8EA920985A404AAB8DC567FD /* SvgRenderer.cpp */; };
-		920B181BF6964B26BFCC444B /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6CC09DBF475C4D36864D4570 /* ci_nanovg_gl.cpp */; };
-		E89522A791E4497A9F282D49 /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E70922F51E6455CAC855BFA /* ci_nanovg.cpp */; };
-		8B42BE299DFD4DE7B815C211 /* SvgRenderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 8A21383DB35944119844AB4D /* SvgRenderer.hpp */; };
-		70CA7ED1C0D24463A8E63626 /* ci_nanovg_gl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 9062C17447E747B884F4D877 /* ci_nanovg_gl.hpp */; };
-		24A0CB997CE047EC92E4A0CF /* ci_nanovg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = BE33BBAFFE4B43C8933AE0DC /* ci_nanovg.hpp */; };
-		89F6DBFE02814C50875D3A65 /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = 374A95C023F5493EA980D291 /* nanovg.c */; };
-		671F44F3B2594BC6ADDD438A /* stb_truetype.h in Headers */ = {isa = PBXBuildFile; fileRef = A39E5BAB9E364E4C8AFE313D /* stb_truetype.h */; };
-		D2C6042B9DB2497FAC1B1793 /* stb_image.h in Headers */ = {isa = PBXBuildFile; fileRef = 423F9BA354544A329E688D60 /* stb_image.h */; };
-		9C547846393E4920BCFCB73F /* nanovg_gl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 86B552677E1F4C9484888FF5 /* nanovg_gl_utils.h */; };
-		B83C1F9DEC7146CA842A3582 /* nanovg_gl.h in Headers */ = {isa = PBXBuildFile; fileRef = 47795C6A6F464A3AA8D196FB /* nanovg_gl.h */; };
-		955F2DBE6966445E92992B95 /* nanovg.h in Headers */ = {isa = PBXBuildFile; fileRef = 445144E18A8947CA93740522 /* nanovg.h */; };
-		6A1A88CA8F364D569999380E /* fontstash.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A6FCC75996D4DA0881B5149 /* fontstash.h */; };
-		C062681C51714E5FB50E1C74 /* HelloSvg_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 80CE1FC48BEC46B782DA3BF1 /* HelloSvg_Prefix.pch */; };
-		B4A6DC8AA17D490A8731E3BC /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DFE42B9AC44B4B9B9F9DD676 /* Images.xcassets */; };
-		82C781FD66EE4CC2BBEC4028 /* CinderApp_ios.png in Resources */ = {isa = PBXBuildFile; fileRef = E417E40005914969B5B977F6 /* CinderApp_ios.png */; };
-		FA01E8AE970F4534878D6507 /* Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = 391770C6B1874F76984B9F18 /* Resources.h */; };
 		806AA2F9844D4F8DB1C1DC87 /* HelloSvgApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BA33CB79CDE2403DA457390D /* HelloSvgApp.cpp */; };
+		809F2549B6EA4CA8B4547FCA /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8EA920985A404AAB8DC567FD /* SvgRenderer.cpp */; };
+		82C781FD66EE4CC2BBEC4028 /* CinderApp_ios.png in Resources */ = {isa = PBXBuildFile; fileRef = E417E40005914969B5B977F6 /* CinderApp_ios.png */; };
+		89F6DBFE02814C50875D3A65 /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = 374A95C023F5493EA980D291 /* nanovg.c */; };
+		920B181BF6964B26BFCC444B /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6CC09DBF475C4D36864D4570 /* ci_nanovg_gl.cpp */; };
+		B4A6DC8AA17D490A8731E3BC /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DFE42B9AC44B4B9B9F9DD676 /* Images.xcassets */; };
+		C725DFFE121DAC7F00FA186B /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02B121B400300192073 /* CoreMedia.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C725E001121DAC8F00FA186B /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C725E000121DAC8F00FA186B /* AVFoundation.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C725E001121DAC8FFFFA18FF /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091FFFF /* ImageIO.framework */; };
+		C727C02E121B400300192073 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02D121B400300192073 /* CoreVideo.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C7FB19D6124BC0D70045AFD2 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */; };
+		DDDDE001121DAC8FFFFADDDD /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */; };
+		E89522A791E4497A9F282D49 /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 4E70922F51E6455CAC855BFA /* ci_nanovg.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		00692BCF14FF149000D0A05E /* HelloSvg.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloSvg.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		00748057165D41390024B57A /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../assets; sourceTree = "<group>"; };
 		0087D25412CD809F002CD69F /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
+		00A66A351965AC8800B17EB3 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		00CFDF6A1138442D0091E310 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		00CFDF6A1138442D0091FFFF /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
-		DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		0A6FCC75996D4DA0881B5149 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fontstash.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		28FD14FF0DC6FC520079059D /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		28FD15070DC6FC5B0079059D /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		374A95C023F5493EA980D291 /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = nanovg.c; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; };
+		391770C6B1874F76984B9F18 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
+		423F9BA354544A329E688D60 /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_image.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; };
+		445144E18A8947CA93740522 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; };
+		47795C6A6F464A3AA8D196FB /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; };
+		4E70922F51E6455CAC855BFA /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; };
+		6CC09DBF475C4D36864D4570 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg_gl.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; };
+		80CE1FC48BEC46B782DA3BF1 /* HelloSvg_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = HelloSvg_Prefix.pch; sourceTree = "<group>"; };
+		86B552677E1F4C9484888FF5 /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl_utils.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; };
+		8A21383DB35944119844AB4D /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = SvgRenderer.hpp; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; };
+		8EA920985A404AAB8DC567FD /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = SvgRenderer.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; };
+		9062C17447E747B884F4D877 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg_gl.hpp; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; };
+		A39E5BAB9E364E4C8AFE313D /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; };
+		BA33CB79CDE2403DA457390D /* HelloSvgApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = HelloSvgApp.cpp; path = ../src/HelloSvgApp.cpp; sourceTree = "<group>"; };
+		BE33BBAFFE4B43C8933AE0DC /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg.hpp; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; };
 		C725E000121DAC8F00FA186B /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		C727C02B121B400300192073 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		C727C02D121B400300192073 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
 		C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		00A66A351965AC8800B17EB3 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
-		00748057165D41390024B57A /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../assets; sourceTree = "<group>"; };
-		BA33CB79CDE2403DA457390D /* HelloSvgApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../src/HelloSvgApp.cpp; sourceTree = "<group>"; name = HelloSvgApp.cpp; };
-		391770C6B1874F76984B9F18 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../include/Resources.h; sourceTree = "<group>"; name = Resources.h; };
-		E417E40005914969B5B977F6 /* CinderApp_ios.png */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../resources/CinderApp_ios.png; sourceTree = "<group>"; name = CinderApp_ios.png; };
-		DFE42B9AC44B4B9B9F9DD676 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = Images.xcassets; sourceTree = "<group>"; name = Images.xcassets; };
-		DDB851CF8871456CAEC52F42 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		80CE1FC48BEC46B782DA3BF1 /* HelloSvg_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = HelloSvg_Prefix.pch; sourceTree = "<group>"; name = HelloSvg_Prefix.pch; };
-		0A6FCC75996D4DA0881B5149 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; name = fontstash.h; };
-		445144E18A8947CA93740522 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; name = nanovg.h; };
-		47795C6A6F464A3AA8D196FB /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; name = nanovg_gl.h; };
-		86B552677E1F4C9484888FF5 /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; name = nanovg_gl_utils.h; };
-		423F9BA354544A329E688D60 /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; name = stb_image.h; };
-		A39E5BAB9E364E4C8AFE313D /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; name = stb_truetype.h; };
-		374A95C023F5493EA980D291 /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; name = nanovg.c; };
-		BE33BBAFFE4B43C8933AE0DC /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; name = ci_nanovg.hpp; };
-		9062C17447E747B884F4D877 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; name = ci_nanovg_gl.hpp; };
-		8A21383DB35944119844AB4D /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; name = SvgRenderer.hpp; };
-		4E70922F51E6455CAC855BFA /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; name = ci_nanovg.cpp; };
-		6CC09DBF475C4D36864D4570 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; name = ci_nanovg_gl.cpp; };
-		8EA920985A404AAB8DC567FD /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; name = SvgRenderer.cpp; };
+		DDB851CF8871456CAEC52F42 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		DFE42B9AC44B4B9B9F9DD676 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = Images.xcassets; sourceTree = "<group>"; };
+		E417E40005914969B5B977F6 /* CinderApp_ios.png */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = CinderApp_ios.png; path = ../resources/CinderApp_ios.png; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,6 +131,33 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		00692BD914FF149000D0A05E /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				BA33CB79CDE2403DA457390D /* HelloSvgApp.cpp */,
+			);
+			name = Source;
+			sourceTree = "<group>";
+		};
+		00692BD914FF149000D0FFFF /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				00748057165D41390024B57A /* assets */,
+				E417E40005914969B5B977F6 /* CinderApp_ios.png */,
+				DFE42B9AC44B4B9B9F9DD676 /* Images.xcassets */,
+				DDB851CF8871456CAEC52F42 /* Info.plist */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		0B45379F5650452EA07352FD /* deps */ = {
+			isa = PBXGroup;
+			children = (
+				2C3A8EF1230C4A6F86968D37 /* nanovg */,
+			);
+			name = deps;
+			sourceTree = "<group>";
+		};
 		1E09FCD16E464DC396C7D0F8 /* src */ = {
 			isa = PBXGroup;
 			children = (
@@ -176,22 +180,14 @@
 			name = nanovg;
 			sourceTree = "<group>";
 		};
-		0B45379F5650452EA07352FD /* deps */ = {
+		6FC425D14D104F01B18D38B0 /* NanoVG */ = {
 			isa = PBXGroup;
 			children = (
-				2C3A8EF1230C4A6F86968D37 /* nanovg */,
+				0B45379F5650452EA07352FD /* deps */,
+				86C2BA08015B4EEEBD024F51 /* include */,
+				81F97E3E587A4666A560E734 /* src */,
 			);
-			name = deps;
-			sourceTree = "<group>";
-		};
-		86C2BA08015B4EEEBD024F51 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				BE33BBAFFE4B43C8933AE0DC /* ci_nanovg.hpp */,
-				9062C17447E747B884F4D877 /* ci_nanovg_gl.hpp */,
-				8A21383DB35944119844AB4D /* SvgRenderer.hpp */,
-			);
-			name = include;
+			name = NanoVG;
 			sourceTree = "<group>";
 		};
 		81F97E3E587A4666A560E734 /* src */ = {
@@ -204,22 +200,14 @@
 			name = src;
 			sourceTree = "<group>";
 		};
-		6FC425D14D104F01B18D38B0 /* NanoVG */ = {
+		86C2BA08015B4EEEBD024F51 /* include */ = {
 			isa = PBXGroup;
 			children = (
-				0B45379F5650452EA07352FD /* deps */,
-				86C2BA08015B4EEEBD024F51 /* include */,
-				81F97E3E587A4666A560E734 /* src */,
+				BE33BBAFFE4B43C8933AE0DC /* ci_nanovg.hpp */,
+				9062C17447E747B884F4D877 /* ci_nanovg_gl.hpp */,
+				8A21383DB35944119844AB4D /* SvgRenderer.hpp */,
 			);
-			name = NanoVG;
-			sourceTree = "<group>";
-		};
-		99692BD914FF149000DFFFFF /* Blocks */ = {
-			isa = PBXGroup;
-			children = (
-				6FC425D14D104F01B18D38B0 /* NanoVG */,
-			);
-			name = Blocks;
+			name = include;
 			sourceTree = "<group>";
 		};
 		99692BD914FF149000D0A05F /* Headers */ = {
@@ -231,23 +219,12 @@
 			name = Headers;
 			sourceTree = "<group>";
 		};
-		00692BD914FF149000D0A05E /* Source */ = {
+		99692BD914FF149000DFFFFF /* Blocks */ = {
 			isa = PBXGroup;
 			children = (
-				BA33CB79CDE2403DA457390D /* HelloSvgApp.cpp */,
+				6FC425D14D104F01B18D38B0 /* NanoVG */,
 			);
-			name = Source;
-			sourceTree = "<group>";
-		};
-		00692BD914FF149000D0FFFF /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				00748057165D41390024B57A /* assets */,
-				E417E40005914969B5B977F6 /* CinderApp_ios.png */,
-				DFE42B9AC44B4B9B9F9DD676 /* Images.xcassets */,
-				DDB851CF8871456CAEC52F42 /* Info.plist */,
-			);
-			name = Resources;
+			name = Blocks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -275,6 +252,8 @@
 /* Begin PBXProject section */
 		00692BC614FF149000D0A05E /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 00692BC914FF149000D0A05E /* Build configuration list for PBXProject "HelloSvg" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -324,14 +303,18 @@
 		00692BF314FF149000D0A05E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "LaunchImage";
-				DEAD_CODE_STRIPPING = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv7,
+					arm64,
+				);
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CINDER_PATH = ../../../../..;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				ARCHS = "armv7 arm64";
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -344,26 +327,26 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				CINDER_PATH = "../../../../..";
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Debug;
 		};
 		00692BF414FF149000D0A05E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "LaunchImage";
-				DEAD_CODE_STRIPPING = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD)";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
@@ -373,14 +356,13 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				USER_HEADER_SEARCH_PATHS = ../include;
 				VALIDATE_PRODUCT = YES;
-				CINDER_PATH = "../../../../..";
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
 			};
 			name = Release;
 		};
@@ -388,10 +370,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "HelloSvg_Prefix.pch";
-				INFOPLIST_FILE = "Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
+				GCC_PREFIX_HEADER = HelloSvg_Prefix.pch;
+				INFOPLIST_FILE = Info.plist;
 				"OTHER_LDFLAGS[sdk=iphoneos*][arch=*]" = (
 					"\"$(CINDER_PATH)/lib/libcinder-iphone_d.a\"",
 					"-lz",
@@ -400,6 +380,8 @@
 					"\"$(CINDER_PATH)/lib/libcinder-iphone-sim_d.a\"",
 					"-lz",
 				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
@@ -407,10 +389,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "HelloSvg_Prefix.pch";
-				INFOPLIST_FILE = "Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
+				GCC_PREFIX_HEADER = HelloSvg_Prefix.pch;
+				INFOPLIST_FILE = Info.plist;
 				"OTHER_LDFLAGS[sdk=iphoneos*][arch=*]" = (
 					"\"$(CINDER_PATH)/lib/libcinder-iphone.a\"",
 					"-lz",
@@ -419,6 +399,8 @@
 					"\"$(CINDER_PATH)/lib/libcinder-iphone-sim.a\"",
 					"-lz",
 				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};

--- a/samples/HelloWorld/xcode/HelloWorld.xcodeproj/project.pbxproj
+++ b/samples/HelloWorld/xcode/HelloWorld.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,26 +14,16 @@
 		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		36096922A2524D39806D833F /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85A40458CECF4D5AB7C0ACF5 /* ci_nanovg.cpp */; };
+		4ADC8727BB9C4625B440ABBF /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5153DC3B34764EE8B2BAA72F /* SvgRenderer.cpp */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-		4ADC8727BB9C4625B440ABBF /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5153DC3B34764EE8B2BAA72F /* SvgRenderer.cpp */; };
-		C8807AE880FC4E4C98575500 /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663B792339D14AED82A79783 /* ci_nanovg_gl.cpp */; };
-		36096922A2524D39806D833F /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 85A40458CECF4D5AB7C0ACF5 /* ci_nanovg.cpp */; };
-		F738583486E04D8DAD5B5C9B /* SvgRenderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 4B0F3019D5464AE9B417100C /* SvgRenderer.hpp */; };
-		BDC5F9884FCC482AA30FEE9D /* ci_nanovg_gl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 65D262F7F44C413E98CA03E3 /* ci_nanovg_gl.hpp */; };
-		CA899E528D444008AF183B85 /* ci_nanovg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 22A2C41E736F42848FF14FA8 /* ci_nanovg.hpp */; };
 		A967163E3C724F1AB39C33D0 /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = 59C737DC7B8D45DAAE5202F6 /* nanovg.c */; };
-		97EFDF28705246FCA5BE2A62 /* stb_truetype.h in Headers */ = {isa = PBXBuildFile; fileRef = B755786403424F2DB9B3F01E /* stb_truetype.h */; };
-		2B601D2FECC3467CA1AAA9ED /* stb_image.h in Headers */ = {isa = PBXBuildFile; fileRef = BF37075F32854494AE7525DB /* stb_image.h */; };
-		1D0B3D7BC0B54CFDB7AFC9B3 /* nanovg_gl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 64A54F87B146437A9AC619EB /* nanovg_gl_utils.h */; };
-		400601AD4BBE49768A219A3E /* nanovg_gl.h in Headers */ = {isa = PBXBuildFile; fileRef = 0D26869611904EE29507B92A /* nanovg_gl.h */; };
-		D86FE5322132412DAEA496C1 /* nanovg.h in Headers */ = {isa = PBXBuildFile; fileRef = 7845BE3148004424B3B01990 /* nanovg.h */; };
-		E203F2092A274891BF549828 /* fontstash.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FFA3B4F9F0241B58754D677 /* fontstash.h */; };
-		3EA562C066B547519FCBCEB9 /* HelloWorld_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = B09D187F323544EA80FC07A0 /* HelloWorld_Prefix.pch */; };
-		C4DAC764A27C48D599DCCCC6 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = 0149862C1DA24CE1A1D63382 /* CinderApp.icns */; };
-		47BBE73CB00F418D9450B44E /* Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = 78896EB713C940BA9032EA2C /* Resources.h */; };
 		B2A840C7671945B0BC6108BB /* HelloWorldApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5D90083013FF4198B570B8D5 /* HelloWorldApp.cpp */; };
+		C4DAC764A27C48D599DCCCC6 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = 0149862C1DA24CE1A1D63382 /* CinderApp.icns */; };
+		C8807AE880FC4E4C98575500 /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 663B792339D14AED82A79783 /* ci_nanovg_gl.cpp */; };
+		D8634A001B39243E00B5C3D9 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D86349FF1B39243E00B5C3D9 /* IOKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -44,30 +34,31 @@
 		00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
 		00B784B10FF439BC000DE1D7 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
+		0149862C1DA24CE1A1D63382 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; };
+		0D26869611904EE29507B92A /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		22A2C41E736F42848FF14FA8 /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg.hpp; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; };
+		2453B3C6F0144C6B930FE5A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		4B0F3019D5464AE9B417100C /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = SvgRenderer.hpp; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; };
+		5153DC3B34764EE8B2BAA72F /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = SvgRenderer.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; };
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
+		59C737DC7B8D45DAAE5202F6 /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = nanovg.c; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; };
+		5D90083013FF4198B570B8D5 /* HelloWorldApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = HelloWorldApp.cpp; path = ../src/HelloWorldApp.cpp; sourceTree = "<group>"; };
+		64A54F87B146437A9AC619EB /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl_utils.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; };
+		65D262F7F44C413E98CA03E3 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg_gl.hpp; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; };
+		663B792339D14AED82A79783 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg_gl.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; };
+		7845BE3148004424B3B01990 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; };
+		78896EB713C940BA9032EA2C /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
+		85A40458CECF4D5AB7C0ACF5 /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		5D90083013FF4198B570B8D5 /* HelloWorldApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../src/HelloWorldApp.cpp; sourceTree = "<group>"; name = HelloWorldApp.cpp; };
-		78896EB713C940BA9032EA2C /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../include/Resources.h; sourceTree = "<group>"; name = Resources.h; };
-		0149862C1DA24CE1A1D63382 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
-		2453B3C6F0144C6B930FE5A8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		B09D187F323544EA80FC07A0 /* HelloWorld_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = HelloWorld_Prefix.pch; sourceTree = "<group>"; name = HelloWorld_Prefix.pch; };
-		8FFA3B4F9F0241B58754D677 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; name = fontstash.h; };
-		7845BE3148004424B3B01990 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; name = nanovg.h; };
-		0D26869611904EE29507B92A /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; name = nanovg_gl.h; };
-		64A54F87B146437A9AC619EB /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; name = nanovg_gl_utils.h; };
-		BF37075F32854494AE7525DB /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; name = stb_image.h; };
-		B755786403424F2DB9B3F01E /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; name = stb_truetype.h; };
-		59C737DC7B8D45DAAE5202F6 /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; name = nanovg.c; };
-		22A2C41E736F42848FF14FA8 /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; name = ci_nanovg.hpp; };
-		65D262F7F44C413E98CA03E3 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; name = ci_nanovg_gl.hpp; };
-		4B0F3019D5464AE9B417100C /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; name = SvgRenderer.hpp; };
-		85A40458CECF4D5AB7C0ACF5 /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; name = ci_nanovg.cpp; };
-		663B792339D14AED82A79783 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; name = ci_nanovg_gl.cpp; };
-		5153DC3B34764EE8B2BAA72F /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; name = SvgRenderer.cpp; };
+		8FFA3B4F9F0241B58754D677 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fontstash.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; };
+		B09D187F323544EA80FC07A0 /* HelloWorld_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = HelloWorld_Prefix.pch; sourceTree = "<group>"; };
+		B755786403424F2DB9B3F01E /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; };
+		BF37075F32854494AE7525DB /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_image.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; };
+		D86349FF1B39243E00B5C3D9 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +66,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8634A001B39243E00B5C3D9 /* IOKit.framework in Frameworks */,
 				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
 				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
@@ -91,6 +83,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+				C1AE792326DD46109AFF9609 /* NanoVG */,
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
 		080E96DDFE201D6D7F000001 /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -102,6 +102,7 @@
 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D86349FF1B39243E00B5C3D9 /* IOKit.framework */,
 				006D720219952D00008149E2 /* AVFoundation.framework */,
 				006D720319952D00008149E2 /* CoreMedia.framework */,
 				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
@@ -146,6 +147,43 @@
 			name = HelloWorld;
 			sourceTree = "<group>";
 		};
+		29B97315FDCFA39411CA2CEA /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				78896EB713C940BA9032EA2C /* Resources.h */,
+				B09D187F323544EA80FC07A0 /* HelloWorld_Prefix.pch */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		29B97317FDCFA39411CA2CEA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				0149862C1DA24CE1A1D63382 /* CinderApp.icns */,
+				2453B3C6F0144C6B930FE5A8 /* Info.plist */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
+				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3A4B00DE5A2B46708133C552 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				85A40458CECF4D5AB7C0ACF5 /* ci_nanovg.cpp */,
+				663B792339D14AED82A79783 /* ci_nanovg_gl.cpp */,
+				5153DC3B34764EE8B2BAA72F /* SvgRenderer.cpp */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
 		764FA817D0184E2F9F7F574F /* src */ = {
 			isa = PBXGroup;
 			children = (
@@ -176,26 +214,6 @@
 			name = deps;
 			sourceTree = "<group>";
 		};
-		C9CC2D12940040D7AC212891 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				22A2C41E736F42848FF14FA8 /* ci_nanovg.hpp */,
-				65D262F7F44C413E98CA03E3 /* ci_nanovg_gl.hpp */,
-				4B0F3019D5464AE9B417100C /* SvgRenderer.hpp */,
-			);
-			name = include;
-			sourceTree = "<group>";
-		};
-		3A4B00DE5A2B46708133C552 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				85A40458CECF4D5AB7C0ACF5 /* ci_nanovg.cpp */,
-				663B792339D14AED82A79783 /* ci_nanovg_gl.cpp */,
-				5153DC3B34764EE8B2BAA72F /* SvgRenderer.cpp */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
 		C1AE792326DD46109AFF9609 /* NanoVG */ = {
 			isa = PBXGroup;
 			children = (
@@ -206,39 +224,14 @@
 			name = NanoVG;
 			sourceTree = "<group>";
 		};
-		01B97315FEAEA392516A2CEA /* Blocks */ = {
+		C9CC2D12940040D7AC212891 /* include */ = {
 			isa = PBXGroup;
 			children = (
-				C1AE792326DD46109AFF9609 /* NanoVG */,
+				22A2C41E736F42848FF14FA8 /* ci_nanovg.hpp */,
+				65D262F7F44C413E98CA03E3 /* ci_nanovg_gl.hpp */,
+				4B0F3019D5464AE9B417100C /* SvgRenderer.hpp */,
 			);
-			name = Blocks;
-			sourceTree = "<group>";
-		};
-		29B97315FDCFA39411CA2CEA /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				78896EB713C940BA9032EA2C /* Resources.h */,
-				B09D187F323544EA80FC07A0 /* HelloWorld_Prefix.pch */,
-			);
-			name = Headers;
-			sourceTree = "<group>";
-		};
-		29B97317FDCFA39411CA2CEA /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				0149862C1DA24CE1A1D63382 /* CinderApp.icns */,
-				2453B3C6F0144C6B930FE5A8 /* Info.plist */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-		};
-		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
-				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
-			);
-			name = Frameworks;
+			name = include;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -267,6 +260,8 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "HelloWorld" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -317,24 +312,24 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = HelloWorld_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = HelloWorld_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
 				PRODUCT_NAME = HelloWorld;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
@@ -348,54 +343,54 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = HelloWorld_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = HelloWorld_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
 				PRODUCT_NAME = HelloWorld;
 				STRIP_INSTALLED_PRODUCT = YES;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../../..";
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Debug;
 		};
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../../..";
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Release;
 		};

--- a/samples/HelloWorld/xcode_ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/samples/HelloWorld/xcode_ios/HelloWorld.xcodeproj/project.pbxproj
@@ -7,87 +7,64 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00748058165D41390024B57A /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 00748057165D41390024B57A /* assets */; };
 		0087D25512CD809F002CD69F /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0087D25412CD809F002CD69F /* CoreText.framework */; };
+		00A66A361965AC8800B17EB3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A66A351965AC8800B17EB3 /* Accelerate.framework */; };
 		00CFDF6B1138442D0091E310 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091E310 /* CoreGraphics.framework */; };
-		C725E001121DAC8FFFFA18FF /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091FFFF /* ImageIO.framework */; };
-		DDDDE001121DAC8FFFFADDDD /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */; };
+		0FF4D4F14FA2459D9FC0C414 /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF9E86AE6FC44AC6AB13AAAE /* SvgRenderer.cpp */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		28FD15000DC6FC520079059D /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FD14FF0DC6FC520079059D /* OpenGLES.framework */; };
 		28FD15080DC6FC5B0079059D /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FD15070DC6FC5B0079059D /* QuartzCore.framework */; };
-		C725DFFE121DAC7F00FA186B /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02B121B400300192073 /* CoreMedia.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C725E001121DAC8F00FA186B /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C725E000121DAC8F00FA186B /* AVFoundation.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C727C02E121B400300192073 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02D121B400300192073 /* CoreVideo.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C7FB19D6124BC0D70045AFD2 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */; };
-		00A66A361965AC8800B17EB3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A66A351965AC8800B17EB3 /* Accelerate.framework */; };
-		00748058165D41390024B57A /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 00748057165D41390024B57A /* assets */; };
-		0FF4D4F14FA2459D9FC0C414 /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = DF9E86AE6FC44AC6AB13AAAE /* SvgRenderer.cpp */; };
 		309AF3537A5842DDB0B2D217 /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 854A185AAE054346B07C34A7 /* ci_nanovg_gl.cpp */; };
-		960CAC32E17C45ED8A4F17A2 /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 55639E66BDE3480E88873662 /* ci_nanovg.cpp */; };
-		883E931DDE1C4383AABD2813 /* SvgRenderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 0791FD78D3C84C49B2A8F8F3 /* SvgRenderer.hpp */; };
-		52B850695C814544810D5AFA /* ci_nanovg_gl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = CFAD96997E53458B9FA4E11C /* ci_nanovg_gl.hpp */; };
-		E07072323D154AE5BEF7A34D /* ci_nanovg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C9AA3A81FAF74A8890B7CE0B /* ci_nanovg.hpp */; };
-		E61FF4A341EC4BC8B421506C /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = 27BAD5A5483D49B1A802BCE6 /* nanovg.c */; };
-		B395833541E043718C88DE59 /* stb_truetype.h in Headers */ = {isa = PBXBuildFile; fileRef = B79E18A32395471AB728ACBE /* stb_truetype.h */; };
-		48C09B023AFB43FE86815733 /* stb_image.h in Headers */ = {isa = PBXBuildFile; fileRef = E6277BC18D344C3A8EFB61EB /* stb_image.h */; };
-		DBF0A969AC774FE3A1E08134 /* nanovg_gl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 03189B2AB6DB4E5BA1E475F0 /* nanovg_gl_utils.h */; };
-		D8862BAE34AD4F39ADA155D6 /* nanovg_gl.h in Headers */ = {isa = PBXBuildFile; fileRef = AF3DCEEFCAB94ED5975BA7F0 /* nanovg_gl.h */; };
-		20F62AA2723A4144B3574627 /* nanovg.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A096D09D0C4495DA2E83A5A /* nanovg.h */; };
-		9E831E69E81F47E5A487347E /* fontstash.h in Headers */ = {isa = PBXBuildFile; fileRef = E29E44534D854F0BBE9CC03F /* fontstash.h */; };
-		08484F103F3E4165BE2A8ED1 /* HelloWorld_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = F9DC9CD8B0924EADB42D7E57 /* HelloWorld_Prefix.pch */; };
 		48E6F1D8A3884990A12011AE /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3EDC6901DE9C43948A3C8F0E /* Images.xcassets */; };
-		B15DD46386E4483C8B000C7B /* CinderApp_ios.png in Resources */ = {isa = PBXBuildFile; fileRef = 151F561B58A74388BB9479E7 /* CinderApp_ios.png */; };
-		E9DE1DF35EF247EBA6FE2234 /* Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = C7D528EF333840D6BA54A723 /* Resources.h */; };
 		4B559D9D6B354FBB82922CE6 /* HelloWorldApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B886D1AEE56242A6A8F87DB6 /* HelloWorldApp.cpp */; };
+		960CAC32E17C45ED8A4F17A2 /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 55639E66BDE3480E88873662 /* ci_nanovg.cpp */; };
+		B15DD46386E4483C8B000C7B /* CinderApp_ios.png in Resources */ = {isa = PBXBuildFile; fileRef = 151F561B58A74388BB9479E7 /* CinderApp_ios.png */; };
+		C725DFFE121DAC7F00FA186B /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02B121B400300192073 /* CoreMedia.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C725E001121DAC8F00FA186B /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C725E000121DAC8F00FA186B /* AVFoundation.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C725E001121DAC8FFFFA18FF /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091FFFF /* ImageIO.framework */; };
+		C727C02E121B400300192073 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02D121B400300192073 /* CoreVideo.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C7FB19D6124BC0D70045AFD2 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */; };
+		DDDDE001121DAC8FFFFADDDD /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */; };
+		E61FF4A341EC4BC8B421506C /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = 27BAD5A5483D49B1A802BCE6 /* nanovg.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		00692BCF14FF149000D0A05E /* HelloWorld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HelloWorld.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		00748057165D41390024B57A /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../assets; sourceTree = "<group>"; };
 		0087D25412CD809F002CD69F /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
+		00A66A351965AC8800B17EB3 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		00CFDF6A1138442D0091E310 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		00CFDF6A1138442D0091FFFF /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
-		DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		03189B2AB6DB4E5BA1E475F0 /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl_utils.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; };
+		0791FD78D3C84C49B2A8F8F3 /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = SvgRenderer.hpp; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; };
+		151F561B58A74388BB9479E7 /* CinderApp_ios.png */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = CinderApp_ios.png; path = ../resources/CinderApp_ios.png; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		27BAD5A5483D49B1A802BCE6 /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = nanovg.c; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; };
 		28FD14FF0DC6FC520079059D /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		28FD15070DC6FC5B0079059D /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		3EDC6901DE9C43948A3C8F0E /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = Images.xcassets; sourceTree = "<group>"; };
+		55639E66BDE3480E88873662 /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; };
+		854A185AAE054346B07C34A7 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg_gl.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; };
+		87807C0A1F2F4D8EBE3A9B4E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A096D09D0C4495DA2E83A5A /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; };
+		AF3DCEEFCAB94ED5975BA7F0 /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; };
+		B79E18A32395471AB728ACBE /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; };
+		B886D1AEE56242A6A8F87DB6 /* HelloWorldApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = HelloWorldApp.cpp; path = ../src/HelloWorldApp.cpp; sourceTree = "<group>"; };
 		C725E000121DAC8F00FA186B /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		C727C02B121B400300192073 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		C727C02D121B400300192073 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
+		C7D528EF333840D6BA54A723 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
 		C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		00A66A351965AC8800B17EB3 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
-		00748057165D41390024B57A /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../assets; sourceTree = "<group>"; };
-		B886D1AEE56242A6A8F87DB6 /* HelloWorldApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../src/HelloWorldApp.cpp; sourceTree = "<group>"; name = HelloWorldApp.cpp; };
-		C7D528EF333840D6BA54A723 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../include/Resources.h; sourceTree = "<group>"; name = Resources.h; };
-		151F561B58A74388BB9479E7 /* CinderApp_ios.png */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../resources/CinderApp_ios.png; sourceTree = "<group>"; name = CinderApp_ios.png; };
-		3EDC6901DE9C43948A3C8F0E /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = Images.xcassets; sourceTree = "<group>"; name = Images.xcassets; };
-		87807C0A1F2F4D8EBE3A9B4E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		F9DC9CD8B0924EADB42D7E57 /* HelloWorld_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = HelloWorld_Prefix.pch; sourceTree = "<group>"; name = HelloWorld_Prefix.pch; };
-		E29E44534D854F0BBE9CC03F /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; name = fontstash.h; };
-		9A096D09D0C4495DA2E83A5A /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; name = nanovg.h; };
-		AF3DCEEFCAB94ED5975BA7F0 /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; name = nanovg_gl.h; };
-		03189B2AB6DB4E5BA1E475F0 /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; name = nanovg_gl_utils.h; };
-		E6277BC18D344C3A8EFB61EB /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; name = stb_image.h; };
-		B79E18A32395471AB728ACBE /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; name = stb_truetype.h; };
-		27BAD5A5483D49B1A802BCE6 /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; name = nanovg.c; };
-		C9AA3A81FAF74A8890B7CE0B /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; name = ci_nanovg.hpp; };
-		CFAD96997E53458B9FA4E11C /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; name = ci_nanovg_gl.hpp; };
-		0791FD78D3C84C49B2A8F8F3 /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; name = SvgRenderer.hpp; };
-		55639E66BDE3480E88873662 /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; name = ci_nanovg.cpp; };
-		854A185AAE054346B07C34A7 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; name = ci_nanovg_gl.cpp; };
-		DF9E86AE6FC44AC6AB13AAAE /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; name = SvgRenderer.cpp; };
+		C9AA3A81FAF74A8890B7CE0B /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg.hpp; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; };
+		CFAD96997E53458B9FA4E11C /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg_gl.hpp; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; };
+		DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		DF9E86AE6FC44AC6AB13AAAE /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = SvgRenderer.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; };
+		E29E44534D854F0BBE9CC03F /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fontstash.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; };
+		E6277BC18D344C3A8EFB61EB /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_image.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; };
+		F9DC9CD8B0924EADB42D7E57 /* HelloWorld_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = HelloWorld_Prefix.pch; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,83 +131,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		26C8686D9A8B44F086973998 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				E29E44534D854F0BBE9CC03F /* fontstash.h */,
-				9A096D09D0C4495DA2E83A5A /* nanovg.h */,
-				AF3DCEEFCAB94ED5975BA7F0 /* nanovg_gl.h */,
-				03189B2AB6DB4E5BA1E475F0 /* nanovg_gl_utils.h */,
-				E6277BC18D344C3A8EFB61EB /* stb_image.h */,
-				B79E18A32395471AB728ACBE /* stb_truetype.h */,
-				27BAD5A5483D49B1A802BCE6 /* nanovg.c */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		BF008B2BB7524339A352360C /* nanovg */ = {
-			isa = PBXGroup;
-			children = (
-				26C8686D9A8B44F086973998 /* src */,
-			);
-			name = nanovg;
-			sourceTree = "<group>";
-		};
-		388F83DF38854316A919DDF5 /* deps */ = {
-			isa = PBXGroup;
-			children = (
-				BF008B2BB7524339A352360C /* nanovg */,
-			);
-			name = deps;
-			sourceTree = "<group>";
-		};
-		C5581AC16C404027855F09F1 /* include */ = {
-			isa = PBXGroup;
-			children = (
-				C9AA3A81FAF74A8890B7CE0B /* ci_nanovg.hpp */,
-				CFAD96997E53458B9FA4E11C /* ci_nanovg_gl.hpp */,
-				0791FD78D3C84C49B2A8F8F3 /* SvgRenderer.hpp */,
-			);
-			name = include;
-			sourceTree = "<group>";
-		};
-		78A4916B47FF47F590CA045E /* src */ = {
-			isa = PBXGroup;
-			children = (
-				55639E66BDE3480E88873662 /* ci_nanovg.cpp */,
-				854A185AAE054346B07C34A7 /* ci_nanovg_gl.cpp */,
-				DF9E86AE6FC44AC6AB13AAAE /* SvgRenderer.cpp */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		13F779AC687144279CE08146 /* NanoVG */ = {
-			isa = PBXGroup;
-			children = (
-				388F83DF38854316A919DDF5 /* deps */,
-				C5581AC16C404027855F09F1 /* include */,
-				78A4916B47FF47F590CA045E /* src */,
-			);
-			name = NanoVG;
-			sourceTree = "<group>";
-		};
-		99692BD914FF149000DFFFFF /* Blocks */ = {
-			isa = PBXGroup;
-			children = (
-				13F779AC687144279CE08146 /* NanoVG */,
-			);
-			name = Blocks;
-			sourceTree = "<group>";
-		};
-		99692BD914FF149000D0A05F /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				C7D528EF333840D6BA54A723 /* Resources.h */,
-				F9DC9CD8B0924EADB42D7E57 /* HelloWorld_Prefix.pch */,
-			);
-			name = Headers;
-			sourceTree = "<group>";
-		};
 		00692BD914FF149000D0A05E /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -248,6 +148,83 @@
 				87807C0A1F2F4D8EBE3A9B4E /* Info.plist */,
 			);
 			name = Resources;
+			sourceTree = "<group>";
+		};
+		13F779AC687144279CE08146 /* NanoVG */ = {
+			isa = PBXGroup;
+			children = (
+				388F83DF38854316A919DDF5 /* deps */,
+				C5581AC16C404027855F09F1 /* include */,
+				78A4916B47FF47F590CA045E /* src */,
+			);
+			name = NanoVG;
+			sourceTree = "<group>";
+		};
+		26C8686D9A8B44F086973998 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				E29E44534D854F0BBE9CC03F /* fontstash.h */,
+				9A096D09D0C4495DA2E83A5A /* nanovg.h */,
+				AF3DCEEFCAB94ED5975BA7F0 /* nanovg_gl.h */,
+				03189B2AB6DB4E5BA1E475F0 /* nanovg_gl_utils.h */,
+				E6277BC18D344C3A8EFB61EB /* stb_image.h */,
+				B79E18A32395471AB728ACBE /* stb_truetype.h */,
+				27BAD5A5483D49B1A802BCE6 /* nanovg.c */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		388F83DF38854316A919DDF5 /* deps */ = {
+			isa = PBXGroup;
+			children = (
+				BF008B2BB7524339A352360C /* nanovg */,
+			);
+			name = deps;
+			sourceTree = "<group>";
+		};
+		78A4916B47FF47F590CA045E /* src */ = {
+			isa = PBXGroup;
+			children = (
+				55639E66BDE3480E88873662 /* ci_nanovg.cpp */,
+				854A185AAE054346B07C34A7 /* ci_nanovg_gl.cpp */,
+				DF9E86AE6FC44AC6AB13AAAE /* SvgRenderer.cpp */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		99692BD914FF149000D0A05F /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				C7D528EF333840D6BA54A723 /* Resources.h */,
+				F9DC9CD8B0924EADB42D7E57 /* HelloWorld_Prefix.pch */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		99692BD914FF149000DFFFFF /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+				13F779AC687144279CE08146 /* NanoVG */,
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
+		BF008B2BB7524339A352360C /* nanovg */ = {
+			isa = PBXGroup;
+			children = (
+				26C8686D9A8B44F086973998 /* src */,
+			);
+			name = nanovg;
+			sourceTree = "<group>";
+		};
+		C5581AC16C404027855F09F1 /* include */ = {
+			isa = PBXGroup;
+			children = (
+				C9AA3A81FAF74A8890B7CE0B /* ci_nanovg.hpp */,
+				CFAD96997E53458B9FA4E11C /* ci_nanovg_gl.hpp */,
+				0791FD78D3C84C49B2A8F8F3 /* SvgRenderer.hpp */,
+			);
+			name = include;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -275,6 +252,8 @@
 /* Begin PBXProject section */
 		00692BC614FF149000D0A05E /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 00692BC914FF149000D0A05E /* Build configuration list for PBXProject "HelloWorld" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -324,14 +303,18 @@
 		00692BF314FF149000D0A05E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "LaunchImage";
-				DEAD_CODE_STRIPPING = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv7,
+					arm64,
+				);
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CINDER_PATH = ../../../../..;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				ARCHS = "armv7 arm64";
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -344,26 +327,26 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				CINDER_PATH = "../../../../..";
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Debug;
 		};
 		00692BF414FF149000D0A05E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "LaunchImage";
-				DEAD_CODE_STRIPPING = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD)";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
@@ -373,14 +356,13 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				USER_HEADER_SEARCH_PATHS = ../include;
 				VALIDATE_PRODUCT = YES;
-				CINDER_PATH = "../../../../..";
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
 			};
 			name = Release;
 		};
@@ -388,10 +370,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "HelloWorld_Prefix.pch";
-				INFOPLIST_FILE = "Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
+				GCC_PREFIX_HEADER = HelloWorld_Prefix.pch;
+				INFOPLIST_FILE = Info.plist;
 				"OTHER_LDFLAGS[sdk=iphoneos*][arch=*]" = (
 					"\"$(CINDER_PATH)/lib/libcinder-iphone_d.a\"",
 					"-lz",
@@ -400,6 +380,8 @@
 					"\"$(CINDER_PATH)/lib/libcinder-iphone-sim_d.a\"",
 					"-lz",
 				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
@@ -407,10 +389,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "HelloWorld_Prefix.pch";
-				INFOPLIST_FILE = "Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
+				GCC_PREFIX_HEADER = HelloWorld_Prefix.pch;
+				INFOPLIST_FILE = Info.plist;
 				"OTHER_LDFLAGS[sdk=iphoneos*][arch=*]" = (
 					"\"$(CINDER_PATH)/lib/libcinder-iphone.a\"",
 					"-lz",
@@ -419,6 +399,8 @@
 					"\"$(CINDER_PATH)/lib/libcinder-iphone-sim.a\"",
 					"-lz",
 				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};

--- a/samples/MultiWindow/xcode/MultiWindow.xcodeproj/project.pbxproj
+++ b/samples/MultiWindow/xcode/MultiWindow.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,29 +14,20 @@
 		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		2B2FF55D0F0044A0B3C8249F /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = C60688CBADB04452ACAC2ADE /* nanovg.c */; };
+		36AB83036C1B4DABA3F7D3D1 /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E89198BF0E564531B1CDA5AB /* ci_nanovg_gl.cpp */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-		C3D9AF50729143DD8B208E8D /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 614F60A623764E308F6E3B65 /* SvgRenderer.cpp */; };
-		36AB83036C1B4DABA3F7D3D1 /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E89198BF0E564531B1CDA5AB /* ci_nanovg_gl.cpp */; };
-		C1EECDDB7F2B4178A2509A80 /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A1DED751C94902B6ED293F /* ci_nanovg.cpp */; };
-		A4120D2D280D47B189CCE2DF /* SvgRenderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F6EE405BF41E4AE2B6D5F72B /* SvgRenderer.hpp */; };
-		9776E2120DDF4528B19F090F /* ci_nanovg_gl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 6BBD181B497F428A8DD824CB /* ci_nanovg_gl.hpp */; };
-		09693DF06C35487AA95B3838 /* ci_nanovg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = C06B1D2B83ED45B687945B5C /* ci_nanovg.hpp */; };
-		2B2FF55D0F0044A0B3C8249F /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = C60688CBADB04452ACAC2ADE /* nanovg.c */; };
-		DBD260FB487A49F285B562F5 /* stb_truetype.h in Headers */ = {isa = PBXBuildFile; fileRef = 003A927FFE474A91B1CBE579 /* stb_truetype.h */; };
-		32BB218D6EAB41D88D9F99BF /* stb_image.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D71086DA1B24110A93714C4 /* stb_image.h */; };
-		4E2B9C25182B4F8FB3B2D257 /* nanovg_gl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 38B5C764DE684F329B160E2B /* nanovg_gl_utils.h */; };
-		E00ED594D274411D968228C8 /* nanovg_gl.h in Headers */ = {isa = PBXBuildFile; fileRef = 760F3FC3618640A493C38F78 /* nanovg_gl.h */; };
-		851030C7201E498990AEA751 /* nanovg.h in Headers */ = {isa = PBXBuildFile; fileRef = DA1F1D636DFC4584B3F2243A /* nanovg.h */; };
-		8C313E426E734216BD45FDEC /* fontstash.h in Headers */ = {isa = PBXBuildFile; fileRef = DC36A3AD561F4DC5A6D8D46B /* fontstash.h */; };
-		B1CDEC539B0C4E2297A285EA /* MultiWindow_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 941A0E2742974FEA8ED23F18 /* MultiWindow_Prefix.pch */; };
 		96B698272F8F4714B99ED466 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = 6397D4420B34495398047FFA /* CinderApp.icns */; };
-		F627471A824046AF8FB77CD8 /* Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B5635CBBD5540EC85B94809 /* Resources.h */; };
 		99485653E94049DAB1DD9069 /* MultiWindowApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70B967BF02464724B2A7CF79 /* MultiWindowApp.cpp */; };
+		C1EECDDB7F2B4178A2509A80 /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C9A1DED751C94902B6ED293F /* ci_nanovg.cpp */; };
+		C3D9AF50729143DD8B208E8D /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 614F60A623764E308F6E3B65 /* SvgRenderer.cpp */; };
+		D8634A021B39249500B5C3D9 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8634A011B39249500B5C3D9 /* IOKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		003A927FFE474A91B1CBE579 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; };
 		006D720219952D00008149E2 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		006D720319952D00008149E2 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		0091D8F80E81B9330029341E /* OpenGL.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGL.framework; path = /System/Library/Frameworks/OpenGL.framework; sourceTree = "<absolute>"; };
@@ -47,27 +38,27 @@
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		38B5C764DE684F329B160E2B /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl_utils.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; };
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
+		5B5635CBBD5540EC85B94809 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
+		614F60A623764E308F6E3B65 /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = SvgRenderer.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; };
+		6397D4420B34495398047FFA /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; };
+		6BBD181B497F428A8DD824CB /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg_gl.hpp; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; };
+		6D71086DA1B24110A93714C4 /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_image.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; };
+		70B967BF02464724B2A7CF79 /* MultiWindowApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = MultiWindowApp.cpp; path = ../src/MultiWindowApp.cpp; sourceTree = "<group>"; };
+		760F3FC3618640A493C38F78 /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* MultiWindow.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = MultiWindow.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		70B967BF02464724B2A7CF79 /* MultiWindowApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../src/MultiWindowApp.cpp; sourceTree = "<group>"; name = MultiWindowApp.cpp; };
-		5B5635CBBD5540EC85B94809 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../include/Resources.h; sourceTree = "<group>"; name = Resources.h; };
-		6397D4420B34495398047FFA /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
-		AB6123F538024125999A940C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		941A0E2742974FEA8ED23F18 /* MultiWindow_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = MultiWindow_Prefix.pch; sourceTree = "<group>"; name = MultiWindow_Prefix.pch; };
-		DC36A3AD561F4DC5A6D8D46B /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; name = fontstash.h; };
-		DA1F1D636DFC4584B3F2243A /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; name = nanovg.h; };
-		760F3FC3618640A493C38F78 /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; name = nanovg_gl.h; };
-		38B5C764DE684F329B160E2B /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; name = nanovg_gl_utils.h; };
-		6D71086DA1B24110A93714C4 /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; name = stb_image.h; };
-		003A927FFE474A91B1CBE579 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; name = stb_truetype.h; };
-		C60688CBADB04452ACAC2ADE /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; name = nanovg.c; };
-		C06B1D2B83ED45B687945B5C /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; name = ci_nanovg.hpp; };
-		6BBD181B497F428A8DD824CB /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; name = ci_nanovg_gl.hpp; };
-		F6EE405BF41E4AE2B6D5F72B /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; name = SvgRenderer.hpp; };
-		C9A1DED751C94902B6ED293F /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; name = ci_nanovg.cpp; };
-		E89198BF0E564531B1CDA5AB /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; name = ci_nanovg_gl.cpp; };
-		614F60A623764E308F6E3B65 /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; name = SvgRenderer.cpp; };
+		941A0E2742974FEA8ED23F18 /* MultiWindow_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = MultiWindow_Prefix.pch; sourceTree = "<group>"; };
+		AB6123F538024125999A940C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C06B1D2B83ED45B687945B5C /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg.hpp; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; };
+		C60688CBADB04452ACAC2ADE /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = nanovg.c; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; };
+		C9A1DED751C94902B6ED293F /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; };
+		D8634A011B39249500B5C3D9 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		DA1F1D636DFC4584B3F2243A /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; };
+		DC36A3AD561F4DC5A6D8D46B /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fontstash.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; };
+		E89198BF0E564531B1CDA5AB /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg_gl.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; };
+		F6EE405BF41E4AE2B6D5F72B /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = SvgRenderer.hpp; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +66,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8634A021B39249500B5C3D9 /* IOKit.framework in Frameworks */,
 				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
 				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
@@ -91,6 +83,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+				D4BA6AA7089B436D812315BA /* NanoVG */,
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
 		080E96DDFE201D6D7F000001 /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -102,6 +102,7 @@
 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D8634A011B39249500B5C3D9 /* IOKit.framework */,
 				006D720219952D00008149E2 /* AVFoundation.framework */,
 				006D720319952D00008149E2 /* CoreMedia.framework */,
 				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
@@ -146,6 +147,49 @@
 			name = MultiWindow;
 			sourceTree = "<group>";
 		};
+		29B97315FDCFA39411CA2CEA /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				5B5635CBBD5540EC85B94809 /* Resources.h */,
+				941A0E2742974FEA8ED23F18 /* MultiWindow_Prefix.pch */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		29B97317FDCFA39411CA2CEA /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				6397D4420B34495398047FFA /* CinderApp.icns */,
+				AB6123F538024125999A940C /* Info.plist */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
+				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		57AFC53B24374C859EBFC1FE /* deps */ = {
+			isa = PBXGroup;
+			children = (
+				5D73028AC6DD440D8C3D36D2 /* nanovg */,
+			);
+			name = deps;
+			sourceTree = "<group>";
+		};
+		5D73028AC6DD440D8C3D36D2 /* nanovg */ = {
+			isa = PBXGroup;
+			children = (
+				6A0C4A48945C4F63AF6090BB /* src */,
+			);
+			name = nanovg;
+			sourceTree = "<group>";
+		};
 		6A0C4A48945C4F63AF6090BB /* src */ = {
 			isa = PBXGroup;
 			children = (
@@ -158,22 +202,6 @@
 				C60688CBADB04452ACAC2ADE /* nanovg.c */,
 			);
 			name = src;
-			sourceTree = "<group>";
-		};
-		5D73028AC6DD440D8C3D36D2 /* nanovg */ = {
-			isa = PBXGroup;
-			children = (
-				6A0C4A48945C4F63AF6090BB /* src */,
-			);
-			name = nanovg;
-			sourceTree = "<group>";
-		};
-		57AFC53B24374C859EBFC1FE /* deps */ = {
-			isa = PBXGroup;
-			children = (
-				5D73028AC6DD440D8C3D36D2 /* nanovg */,
-			);
-			name = deps;
 			sourceTree = "<group>";
 		};
 		BBE8F7AD8A9B4ECBAE2EE8D5 /* include */ = {
@@ -206,41 +234,6 @@
 			name = NanoVG;
 			sourceTree = "<group>";
 		};
-		01B97315FEAEA392516A2CEA /* Blocks */ = {
-			isa = PBXGroup;
-			children = (
-				D4BA6AA7089B436D812315BA /* NanoVG */,
-			);
-			name = Blocks;
-			sourceTree = "<group>";
-		};
-		29B97315FDCFA39411CA2CEA /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				5B5635CBBD5540EC85B94809 /* Resources.h */,
-				941A0E2742974FEA8ED23F18 /* MultiWindow_Prefix.pch */,
-			);
-			name = Headers;
-			sourceTree = "<group>";
-		};
-		29B97317FDCFA39411CA2CEA /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				6397D4420B34495398047FFA /* CinderApp.icns */,
-				AB6123F538024125999A940C /* Info.plist */,
-			);
-			name = Resources;
-			sourceTree = "<group>";
-		};
-		29B97323FDCFA39411CA2CEA /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */,
-				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -267,6 +260,8 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "MultiWindow" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -317,24 +312,24 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = MultiWindow_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = MultiWindow_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
 				PRODUCT_NAME = MultiWindow;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
@@ -348,54 +343,54 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = MultiWindow_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = MultiWindow_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
 				PRODUCT_NAME = MultiWindow;
 				STRIP_INSTALLED_PRODUCT = YES;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../../..";
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Debug;
 		};
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../../..";
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Release;
 		};

--- a/samples/RenderToTexture/xcode/RenderToTexture.xcodeproj/project.pbxproj
+++ b/samples/RenderToTexture/xcode/RenderToTexture.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -14,26 +14,16 @@
 		00B784B40FF439BC000DE1D7 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B00FF439BC000DE1D7 /* AudioToolbox.framework */; };
 		00B784B50FF439BC000DE1D7 /* AudioUnit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B10FF439BC000DE1D7 /* AudioUnit.framework */; };
 		00B784B60FF439BC000DE1D7 /* CoreAudio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00B784B20FF439BC000DE1D7 /* CoreAudio.framework */; };
+		02CB5600D14E4A3D8D9248A3 /* RenderToTextureApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5A840F6F981942E79088B711 /* RenderToTextureApp.cpp */; };
 		5323E6B20EAFCA74003A9687 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B10EAFCA74003A9687 /* CoreVideo.framework */; };
 		5323E6B60EAFCA7E003A9687 /* QTKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5323E6B50EAFCA7E003A9687 /* QTKit.framework */; };
+		6A25695FBC6F483EBCFB894C /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = EF4F94986DD347D198F49FBA /* nanovg.c */; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
 		9A437DB3E97F47008F93A666 /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FC1488946CC44E109EAB052A /* SvgRenderer.cpp */; };
-		EF9652FBDD4E4F4399DBDF00 /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC8E472CE15E491C9A3649B5 /* ci_nanovg_gl.cpp */; };
 		D853E97AA3D24D68AD07894A /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C97A0DB646184C73BE7C892F /* ci_nanovg.cpp */; };
-		501E98F8EF73416EA695DA71 /* SvgRenderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 3D9422BF556F4A4FBF4A970B /* SvgRenderer.hpp */; };
-		AD3B5256B1A74BA3922B0C7D /* ci_nanovg_gl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = D315003ABE704E52AF1FEF21 /* ci_nanovg_gl.hpp */; };
-		37AEEC8527BA42F6BCAEC0A7 /* ci_nanovg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 11F86062FE1E49B981CE0FC5 /* ci_nanovg.hpp */; };
-		6A25695FBC6F483EBCFB894C /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = EF4F94986DD347D198F49FBA /* nanovg.c */; };
-		22C90BEF22E14CF8951BC356 /* stb_truetype.h in Headers */ = {isa = PBXBuildFile; fileRef = 5856B8CE1E13436086D03946 /* stb_truetype.h */; };
-		D043E071A1E341B08E47F6F2 /* stb_image.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E8ECEE71F624BFBA2A9F541 /* stb_image.h */; };
-		E96C8A649FDA4A30BDEB1438 /* nanovg_gl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 232B0F7BD67F4C95935944BC /* nanovg_gl_utils.h */; };
-		3D47C050C9564DCBBCFFCCD8 /* nanovg_gl.h in Headers */ = {isa = PBXBuildFile; fileRef = 49D69BE54CC94FBA8F718854 /* nanovg_gl.h */; };
-		72256C7E86594743AF5DC579 /* nanovg.h in Headers */ = {isa = PBXBuildFile; fileRef = 658D98E0724149A389FD4826 /* nanovg.h */; };
-		265BD99D14C641A3BDA4083F /* fontstash.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F5FB09F42B8486B8BAF64A3 /* fontstash.h */; };
-		D4C33C7C61194DE5A13020F8 /* RenderToTexture_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = D9DBB3DA8BFD4D4893D49964 /* RenderToTexture_Prefix.pch */; };
+		D8634A041B392B2200B5C3D9 /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D8634A031B392B2200B5C3D9 /* IOKit.framework */; };
 		DCAB05C30EA94FD299367443 /* CinderApp.icns in Resources */ = {isa = PBXBuildFile; fileRef = F47E35DE042B47DEA2921D19 /* CinderApp.icns */; };
-		B129470A8EFD4C35BDEAE0F5 /* Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = E516E0791B864B6E96645814 /* Resources.h */; };
-		02CB5600D14E4A3D8D9248A3 /* RenderToTextureApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5A840F6F981942E79088B711 /* RenderToTextureApp.cpp */; };
+		EF9652FBDD4E4F4399DBDF00 /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AC8E472CE15E491C9A3649B5 /* ci_nanovg_gl.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,29 +35,30 @@
 		00B784B10FF439BC000DE1D7 /* AudioUnit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioUnit.framework; path = System/Library/Frameworks/AudioUnit.framework; sourceTree = SDKROOT; };
 		00B784B20FF439BC000DE1D7 /* CoreAudio.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreAudio.framework; path = System/Library/Frameworks/CoreAudio.framework; sourceTree = SDKROOT; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		11F86062FE1E49B981CE0FC5 /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg.hpp; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; };
+		232B0F7BD67F4C95935944BC /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl_utils.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
+		3D9422BF556F4A4FBF4A970B /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = SvgRenderer.hpp; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; };
+		49D69BE54CC94FBA8F718854 /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; };
 		5323E6B10EAFCA74003A9687 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = /System/Library/Frameworks/CoreVideo.framework; sourceTree = "<absolute>"; };
 		5323E6B50EAFCA7E003A9687 /* QTKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QTKit.framework; path = /System/Library/Frameworks/QTKit.framework; sourceTree = "<absolute>"; };
+		5856B8CE1E13436086D03946 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; };
+		5A840F6F981942E79088B711 /* RenderToTextureApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = RenderToTextureApp.cpp; path = ../src/RenderToTextureApp.cpp; sourceTree = "<group>"; };
+		5E8ECEE71F624BFBA2A9F541 /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_image.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; };
+		658D98E0724149A389FD4826 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; };
+		6622BBA08AAA4584A77835BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8D1107320486CEB800E47090 /* RenderToTexture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RenderToTexture.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		5A840F6F981942E79088B711 /* RenderToTextureApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../src/RenderToTextureApp.cpp; sourceTree = "<group>"; name = RenderToTextureApp.cpp; };
-		E516E0791B864B6E96645814 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../include/Resources.h; sourceTree = "<group>"; name = Resources.h; };
-		F47E35DE042B47DEA2921D19 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; name = CinderApp.icns; };
-		6622BBA08AAA4584A77835BF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		D9DBB3DA8BFD4D4893D49964 /* RenderToTexture_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = RenderToTexture_Prefix.pch; sourceTree = "<group>"; name = RenderToTexture_Prefix.pch; };
-		8F5FB09F42B8486B8BAF64A3 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; name = fontstash.h; };
-		658D98E0724149A389FD4826 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; name = nanovg.h; };
-		49D69BE54CC94FBA8F718854 /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; name = nanovg_gl.h; };
-		232B0F7BD67F4C95935944BC /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; name = nanovg_gl_utils.h; };
-		5E8ECEE71F624BFBA2A9F541 /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; name = stb_image.h; };
-		5856B8CE1E13436086D03946 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; name = stb_truetype.h; };
-		EF4F94986DD347D198F49FBA /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; name = nanovg.c; };
-		11F86062FE1E49B981CE0FC5 /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; name = ci_nanovg.hpp; };
-		D315003ABE704E52AF1FEF21 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; name = ci_nanovg_gl.hpp; };
-		3D9422BF556F4A4FBF4A970B /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; name = SvgRenderer.hpp; };
-		C97A0DB646184C73BE7C892F /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; name = ci_nanovg.cpp; };
-		AC8E472CE15E491C9A3649B5 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; name = ci_nanovg_gl.cpp; };
-		FC1488946CC44E109EAB052A /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; name = SvgRenderer.cpp; };
+		8F5FB09F42B8486B8BAF64A3 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fontstash.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; };
+		AC8E472CE15E491C9A3649B5 /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg_gl.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; };
+		C97A0DB646184C73BE7C892F /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; };
+		D315003ABE704E52AF1FEF21 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg_gl.hpp; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; };
+		D8634A031B392B2200B5C3D9 /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
+		D9DBB3DA8BFD4D4893D49964 /* RenderToTexture_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = RenderToTexture_Prefix.pch; sourceTree = "<group>"; };
+		E516E0791B864B6E96645814 /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
+		EF4F94986DD347D198F49FBA /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = nanovg.c; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; };
+		F47E35DE042B47DEA2921D19 /* CinderApp.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; name = CinderApp.icns; path = ../resources/CinderApp.icns; sourceTree = "<group>"; };
+		FC1488946CC44E109EAB052A /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = SvgRenderer.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -75,6 +66,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8634A041B392B2200B5C3D9 /* IOKit.framework in Frameworks */,
 				006D720419952D00008149E2 /* AVFoundation.framework in Frameworks */,
 				006D720519952D00008149E2 /* CoreMedia.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
@@ -91,6 +83,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01B97315FEAEA392516A2CEA /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+				D7645E5FA9E145FAADFD90E1 /* NanoVG */,
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
 		080E96DDFE201D6D7F000001 /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -102,6 +102,7 @@
 		1058C7A0FEA54F0111CA2CBB /* Linked Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D8634A031B392B2200B5C3D9 /* IOKit.framework */,
 				006D720219952D00008149E2 /* AVFoundation.framework */,
 				006D720319952D00008149E2 /* CoreMedia.framework */,
 				00B784AF0FF439BC000DE1D7 /* Accelerate.framework */,
@@ -146,74 +147,6 @@
 			name = RenderToTexture;
 			sourceTree = "<group>";
 		};
-		7862CEBDC0FE42A2B13FF18C /* src */ = {
-			isa = PBXGroup;
-			children = (
-				8F5FB09F42B8486B8BAF64A3 /* fontstash.h */,
-				658D98E0724149A389FD4826 /* nanovg.h */,
-				49D69BE54CC94FBA8F718854 /* nanovg_gl.h */,
-				232B0F7BD67F4C95935944BC /* nanovg_gl_utils.h */,
-				5E8ECEE71F624BFBA2A9F541 /* stb_image.h */,
-				5856B8CE1E13436086D03946 /* stb_truetype.h */,
-				EF4F94986DD347D198F49FBA /* nanovg.c */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		89C1C54934134405B8C788F7 /* nanovg */ = {
-			isa = PBXGroup;
-			children = (
-				7862CEBDC0FE42A2B13FF18C /* src */,
-			);
-			name = nanovg;
-			sourceTree = "<group>";
-		};
-		DCF485C29DA84364A14F1EDD /* deps */ = {
-			isa = PBXGroup;
-			children = (
-				89C1C54934134405B8C788F7 /* nanovg */,
-			);
-			name = deps;
-			sourceTree = "<group>";
-		};
-		35F3E08929FA42FCAA105E2A /* include */ = {
-			isa = PBXGroup;
-			children = (
-				11F86062FE1E49B981CE0FC5 /* ci_nanovg.hpp */,
-				D315003ABE704E52AF1FEF21 /* ci_nanovg_gl.hpp */,
-				3D9422BF556F4A4FBF4A970B /* SvgRenderer.hpp */,
-			);
-			name = include;
-			sourceTree = "<group>";
-		};
-		5EE19D83200543B18A12DF93 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				C97A0DB646184C73BE7C892F /* ci_nanovg.cpp */,
-				AC8E472CE15E491C9A3649B5 /* ci_nanovg_gl.cpp */,
-				FC1488946CC44E109EAB052A /* SvgRenderer.cpp */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		D7645E5FA9E145FAADFD90E1 /* NanoVG */ = {
-			isa = PBXGroup;
-			children = (
-				DCF485C29DA84364A14F1EDD /* deps */,
-				35F3E08929FA42FCAA105E2A /* include */,
-				5EE19D83200543B18A12DF93 /* src */,
-			);
-			name = NanoVG;
-			sourceTree = "<group>";
-		};
-		01B97315FEAEA392516A2CEA /* Blocks */ = {
-			isa = PBXGroup;
-			children = (
-				D7645E5FA9E145FAADFD90E1 /* NanoVG */,
-			);
-			name = Blocks;
-			sourceTree = "<group>";
-		};
 		29B97315FDCFA39411CA2CEA /* Headers */ = {
 			isa = PBXGroup;
 			children = (
@@ -239,6 +172,66 @@
 				1058C7A2FEA54F0111CA2CBB /* Other Frameworks */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		35F3E08929FA42FCAA105E2A /* include */ = {
+			isa = PBXGroup;
+			children = (
+				11F86062FE1E49B981CE0FC5 /* ci_nanovg.hpp */,
+				D315003ABE704E52AF1FEF21 /* ci_nanovg_gl.hpp */,
+				3D9422BF556F4A4FBF4A970B /* SvgRenderer.hpp */,
+			);
+			name = include;
+			sourceTree = "<group>";
+		};
+		5EE19D83200543B18A12DF93 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				C97A0DB646184C73BE7C892F /* ci_nanovg.cpp */,
+				AC8E472CE15E491C9A3649B5 /* ci_nanovg_gl.cpp */,
+				FC1488946CC44E109EAB052A /* SvgRenderer.cpp */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		7862CEBDC0FE42A2B13FF18C /* src */ = {
+			isa = PBXGroup;
+			children = (
+				8F5FB09F42B8486B8BAF64A3 /* fontstash.h */,
+				658D98E0724149A389FD4826 /* nanovg.h */,
+				49D69BE54CC94FBA8F718854 /* nanovg_gl.h */,
+				232B0F7BD67F4C95935944BC /* nanovg_gl_utils.h */,
+				5E8ECEE71F624BFBA2A9F541 /* stb_image.h */,
+				5856B8CE1E13436086D03946 /* stb_truetype.h */,
+				EF4F94986DD347D198F49FBA /* nanovg.c */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		89C1C54934134405B8C788F7 /* nanovg */ = {
+			isa = PBXGroup;
+			children = (
+				7862CEBDC0FE42A2B13FF18C /* src */,
+			);
+			name = nanovg;
+			sourceTree = "<group>";
+		};
+		D7645E5FA9E145FAADFD90E1 /* NanoVG */ = {
+			isa = PBXGroup;
+			children = (
+				DCF485C29DA84364A14F1EDD /* deps */,
+				35F3E08929FA42FCAA105E2A /* include */,
+				5EE19D83200543B18A12DF93 /* src */,
+			);
+			name = NanoVG;
+			sourceTree = "<group>";
+		};
+		DCF485C29DA84364A14F1EDD /* deps */ = {
+			isa = PBXGroup;
+			children = (
+				89C1C54934134405B8C788F7 /* nanovg */,
+			);
+			name = deps;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -267,6 +260,8 @@
 /* Begin PBXProject section */
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "RenderToTexture" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -317,24 +312,24 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				COMBINE_HIDPI_IMAGES = YES;
-				DEAD_CODE_STRIPPING = YES;
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = RenderToTexture_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = RenderToTexture_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder_d.a\"";
 				PRODUCT_NAME = RenderToTexture;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
@@ -348,54 +343,54 @@
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = RenderToTexture_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
 					"$(inherited)",
 				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = RenderToTexture_Prefix.pch;
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Applications";
 				OTHER_LDFLAGS = "\"$(CINDER_PATH)/lib/libcinder.a\"";
 				PRODUCT_NAME = RenderToTexture;
 				STRIP_INSTALLED_PRODUCT = YES;
-				WRAPPER_EXTENSION = app;
 				SYMROOT = ./build;
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../../..";
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Debug;
 		};
 		C01FCF5008A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				CINDER_PATH = "../../../../..";
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Release;
 		};

--- a/samples/RenderToTexture/xcode_ios/RenderToTexture.xcodeproj/project.pbxproj
+++ b/samples/RenderToTexture/xcode_ios/RenderToTexture.xcodeproj/project.pbxproj
@@ -7,87 +7,64 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00748058165D41390024B57A /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 00748057165D41390024B57A /* assets */; };
 		0087D25512CD809F002CD69F /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0087D25412CD809F002CD69F /* CoreText.framework */; };
+		00A66A361965AC8800B17EB3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A66A351965AC8800B17EB3 /* Accelerate.framework */; };
 		00CFDF6B1138442D0091E310 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091E310 /* CoreGraphics.framework */; };
-		C725E001121DAC8FFFFA18FF /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091FFFF /* ImageIO.framework */; };
-		DDDDE001121DAC8FFFFADDDD /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
+		1DBC36D39A514324862F1514 /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 788BC0561D434BBCBA10E726 /* SvgRenderer.cpp */; };
 		1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1DF5F4DF0D08C38300B7A737 /* UIKit.framework */; };
 		28FD15000DC6FC520079059D /* OpenGLES.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FD14FF0DC6FC520079059D /* OpenGLES.framework */; };
 		28FD15080DC6FC5B0079059D /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28FD15070DC6FC5B0079059D /* QuartzCore.framework */; };
-		C725DFFE121DAC7F00FA186B /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02B121B400300192073 /* CoreMedia.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C725E001121DAC8F00FA186B /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C725E000121DAC8F00FA186B /* AVFoundation.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C727C02E121B400300192073 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02D121B400300192073 /* CoreVideo.framework */; settings = {
-	ATTRIBUTES = (
-		Weak,
-	);
-}; };
-		C7FB19D6124BC0D70045AFD2 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */; };
-		00A66A361965AC8800B17EB3 /* Accelerate.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00A66A351965AC8800B17EB3 /* Accelerate.framework */; };
-		00748058165D41390024B57A /* assets in Resources */ = {isa = PBXBuildFile; fileRef = 00748057165D41390024B57A /* assets */; };
-		1DBC36D39A514324862F1514 /* SvgRenderer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 788BC0561D434BBCBA10E726 /* SvgRenderer.cpp */; };
-		C642F963046B43329C67625B /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45B309A0EBB045F89A5CD9DF /* ci_nanovg_gl.cpp */; };
-		8730C4CDEFEE4D179A9EC19D /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 88377DA42DA1465FBE9474C0 /* ci_nanovg.cpp */; };
-		08B48B2BFC3B4254A1B9C4F7 /* SvgRenderer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 574027D420DE43D894EAF7DC /* SvgRenderer.hpp */; };
-		1B11A6AE26CA41469B166F30 /* ci_nanovg_gl.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 5FFFE7AD2FD643CD918A9285 /* ci_nanovg_gl.hpp */; };
-		FA40CE0D2C5043C0B5B979BD /* ci_nanovg.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F6546D429BAB425EAEF2E135 /* ci_nanovg.hpp */; };
+		35251AF6921E46D290DF2FF3 /* RenderToTextureApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 885D7AC64BD8483E962F7554 /* RenderToTextureApp.cpp */; };
 		789BDCFFDE1B45E1B73EFA92 /* nanovg.c in Sources */ = {isa = PBXBuildFile; fileRef = 565C0E679FE746CD9138D88C /* nanovg.c */; };
-		ABE6EC8DE4884B9BB21FA950 /* stb_truetype.h in Headers */ = {isa = PBXBuildFile; fileRef = DD6A528F507B4C2C982FC4B2 /* stb_truetype.h */; };
-		7414BCB2454B46F38103220A /* stb_image.h in Headers */ = {isa = PBXBuildFile; fileRef = 580CA6D2A3174679B160210C /* stb_image.h */; };
-		F599003BE0644A40BC35144B /* nanovg_gl_utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 214F7A7D98144BF6A49EF2C1 /* nanovg_gl_utils.h */; };
-		F3FFB0B270E34C0196529944 /* nanovg_gl.h in Headers */ = {isa = PBXBuildFile; fileRef = 06CC4C73137C4F4A892E351D /* nanovg_gl.h */; };
-		2BE64CE59AE842AF81DBB7D9 /* nanovg.h in Headers */ = {isa = PBXBuildFile; fileRef = B28FA427C87B4DBA832BA2D6 /* nanovg.h */; };
-		22F5EE64D0D84BD58D0EC46D /* fontstash.h in Headers */ = {isa = PBXBuildFile; fileRef = 4701242ABA77442D8AC961A8 /* fontstash.h */; };
-		326CA3F5A6A64FE4A51E93C8 /* RenderToTexture_Prefix.pch in Headers */ = {isa = PBXBuildFile; fileRef = 24194F6295AA49FE81BC4ADD /* RenderToTexture_Prefix.pch */; };
+		8730C4CDEFEE4D179A9EC19D /* ci_nanovg.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 88377DA42DA1465FBE9474C0 /* ci_nanovg.cpp */; };
 		A0824D5A04B24A0581E68453 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E5AE20449D6467986F5C7E3 /* Images.xcassets */; };
 		AA303BC5BED04E5DA4DFFA44 /* CinderApp_ios.png in Resources */ = {isa = PBXBuildFile; fileRef = 3026B5FD13E1410F8CF2146A /* CinderApp_ios.png */; };
-		722764CC09FD4E4FB6D63280 /* Resources.h in Headers */ = {isa = PBXBuildFile; fileRef = 9C8346E536E44435A9A812FD /* Resources.h */; };
-		35251AF6921E46D290DF2FF3 /* RenderToTextureApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 885D7AC64BD8483E962F7554 /* RenderToTextureApp.cpp */; };
+		C642F963046B43329C67625B /* ci_nanovg_gl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 45B309A0EBB045F89A5CD9DF /* ci_nanovg_gl.cpp */; };
+		C725DFFE121DAC7F00FA186B /* CoreMedia.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02B121B400300192073 /* CoreMedia.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C725E001121DAC8F00FA186B /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C725E000121DAC8F00FA186B /* AVFoundation.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C725E001121DAC8FFFFA18FF /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 00CFDF6A1138442D0091FFFF /* ImageIO.framework */; };
+		C727C02E121B400300192073 /* CoreVideo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C727C02D121B400300192073 /* CoreVideo.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		C7FB19D6124BC0D70045AFD2 /* AudioToolbox.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */; };
+		DDDDE001121DAC8FFFFADDDD /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		00692BCF14FF149000D0A05E /* RenderToTexture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RenderToTexture.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		00748057165D41390024B57A /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../assets; sourceTree = "<group>"; };
 		0087D25412CD809F002CD69F /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
+		00A66A351965AC8800B17EB3 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
 		00CFDF6A1138442D0091E310 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		00CFDF6A1138442D0091FFFF /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = System/Library/Frameworks/ImageIO.framework; sourceTree = SDKROOT; };
-		DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		06CC4C73137C4F4A892E351D /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1DF5F4DF0D08C38300B7A737 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		214F7A7D98144BF6A49EF2C1 /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg_gl_utils.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; };
+		24194F6295AA49FE81BC4ADD /* RenderToTexture_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = RenderToTexture_Prefix.pch; sourceTree = "<group>"; };
 		28FD14FF0DC6FC520079059D /* OpenGLES.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OpenGLES.framework; path = System/Library/Frameworks/OpenGLES.framework; sourceTree = SDKROOT; };
 		28FD15070DC6FC5B0079059D /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		3026B5FD13E1410F8CF2146A /* CinderApp_ios.png */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = CinderApp_ios.png; path = ../resources/CinderApp_ios.png; sourceTree = "<group>"; };
+		45B309A0EBB045F89A5CD9DF /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg_gl.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; };
+		4701242ABA77442D8AC961A8 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = fontstash.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; };
+		565C0E679FE746CD9138D88C /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = nanovg.c; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; };
+		568EF07821894D1C93D52417 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		574027D420DE43D894EAF7DC /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = SvgRenderer.hpp; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; };
+		580CA6D2A3174679B160210C /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_image.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; };
+		5FFFE7AD2FD643CD918A9285 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg_gl.hpp; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; };
+		788BC0561D434BBCBA10E726 /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = SvgRenderer.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; };
+		88377DA42DA1465FBE9474C0 /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = ci_nanovg.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; };
+		885D7AC64BD8483E962F7554 /* RenderToTextureApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; name = RenderToTextureApp.cpp; path = ../src/RenderToTextureApp.cpp; sourceTree = "<group>"; };
+		8E5AE20449D6467986F5C7E3 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = Images.xcassets; sourceTree = "<group>"; };
+		9C8346E536E44435A9A812FD /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Resources.h; path = ../include/Resources.h; sourceTree = "<group>"; };
+		B28FA427C87B4DBA832BA2D6 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = nanovg.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; };
 		C725E000121DAC8F00FA186B /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		C727C02B121B400300192073 /* CoreMedia.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreMedia.framework; path = System/Library/Frameworks/CoreMedia.framework; sourceTree = SDKROOT; };
 		C727C02D121B400300192073 /* CoreVideo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreVideo.framework; path = System/Library/Frameworks/CoreVideo.framework; sourceTree = SDKROOT; };
 		C7FB19D5124BC0D70045AFD2 /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
-		00A66A351965AC8800B17EB3 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
-		00748057165D41390024B57A /* assets */ = {isa = PBXFileReference; lastKnownFileType = folder; name = assets; path = ../assets; sourceTree = "<group>"; };
-		885D7AC64BD8483E962F7554 /* RenderToTextureApp.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../src/RenderToTextureApp.cpp; sourceTree = "<group>"; name = RenderToTextureApp.cpp; };
-		9C8346E536E44435A9A812FD /* Resources.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../include/Resources.h; sourceTree = "<group>"; name = Resources.h; };
-		3026B5FD13E1410F8CF2146A /* CinderApp_ios.png */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../resources/CinderApp_ios.png; sourceTree = "<group>"; name = CinderApp_ios.png; };
-		8E5AE20449D6467986F5C7E3 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = Images.xcassets; sourceTree = "<group>"; name = Images.xcassets; };
-		568EF07821894D1C93D52417 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; name = Info.plist; };
-		24194F6295AA49FE81BC4ADD /* RenderToTexture_Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = RenderToTexture_Prefix.pch; sourceTree = "<group>"; name = RenderToTexture_Prefix.pch; };
-		4701242ABA77442D8AC961A8 /* fontstash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/fontstash.h; sourceTree = "<group>"; name = fontstash.h; };
-		B28FA427C87B4DBA832BA2D6 /* nanovg.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg.h; sourceTree = "<group>"; name = nanovg.h; };
-		06CC4C73137C4F4A892E351D /* nanovg_gl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl.h; sourceTree = "<group>"; name = nanovg_gl.h; };
-		214F7A7D98144BF6A49EF2C1 /* nanovg_gl_utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/nanovg_gl_utils.h; sourceTree = "<group>"; name = nanovg_gl_utils.h; };
-		580CA6D2A3174679B160210C /* stb_image.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_image.h; sourceTree = "<group>"; name = stb_image.h; };
-		DD6A528F507B4C2C982FC4B2 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; name = stb_truetype.h; };
-		565C0E679FE746CD9138D88C /* nanovg.c */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../deps/nanovg/src/nanovg.c; sourceTree = "<group>"; name = nanovg.c; };
-		F6546D429BAB425EAEF2E135 /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; name = ci_nanovg.hpp; };
-		5FFFE7AD2FD643CD918A9285 /* ci_nanovg_gl.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/ci_nanovg_gl.hpp; sourceTree = "<group>"; name = ci_nanovg_gl.hpp; };
-		574027D420DE43D894EAF7DC /* SvgRenderer.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; path = ../../../include/SvgRenderer.hpp; sourceTree = "<group>"; name = SvgRenderer.hpp; };
-		88377DA42DA1465FBE9474C0 /* ci_nanovg.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg.cpp; sourceTree = "<group>"; name = ci_nanovg.cpp; };
-		45B309A0EBB045F89A5CD9DF /* ci_nanovg_gl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/ci_nanovg_gl.cpp; sourceTree = "<group>"; name = ci_nanovg_gl.cpp; };
-		788BC0561D434BBCBA10E726 /* SvgRenderer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.cpp; path = ../../../src/SvgRenderer.cpp; sourceTree = "<group>"; name = SvgRenderer.cpp; };
+		DD6A528F507B4C2C982FC4B2 /* stb_truetype.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = stb_truetype.h; path = ../../../deps/nanovg/src/stb_truetype.h; sourceTree = "<group>"; };
+		DDDDDF6A1138442D0091DDDD /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		F6546D429BAB425EAEF2E135 /* ci_nanovg.hpp */ = {isa = PBXFileReference; lastKnownFileType = "\"\""; name = ci_nanovg.hpp; path = ../../../include/ci_nanovg.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -154,83 +131,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		52C06A2366E3408784FF37B9 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				4701242ABA77442D8AC961A8 /* fontstash.h */,
-				B28FA427C87B4DBA832BA2D6 /* nanovg.h */,
-				06CC4C73137C4F4A892E351D /* nanovg_gl.h */,
-				214F7A7D98144BF6A49EF2C1 /* nanovg_gl_utils.h */,
-				580CA6D2A3174679B160210C /* stb_image.h */,
-				DD6A528F507B4C2C982FC4B2 /* stb_truetype.h */,
-				565C0E679FE746CD9138D88C /* nanovg.c */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		4AA5325281C649059D42688B /* nanovg */ = {
-			isa = PBXGroup;
-			children = (
-				52C06A2366E3408784FF37B9 /* src */,
-			);
-			name = nanovg;
-			sourceTree = "<group>";
-		};
-		FC1625E757134E088DE69B3E /* deps */ = {
-			isa = PBXGroup;
-			children = (
-				4AA5325281C649059D42688B /* nanovg */,
-			);
-			name = deps;
-			sourceTree = "<group>";
-		};
-		BFD1A66EEDCB4C30AFEC8C7C /* include */ = {
-			isa = PBXGroup;
-			children = (
-				F6546D429BAB425EAEF2E135 /* ci_nanovg.hpp */,
-				5FFFE7AD2FD643CD918A9285 /* ci_nanovg_gl.hpp */,
-				574027D420DE43D894EAF7DC /* SvgRenderer.hpp */,
-			);
-			name = include;
-			sourceTree = "<group>";
-		};
-		654171FC48554C1EB167D506 /* src */ = {
-			isa = PBXGroup;
-			children = (
-				88377DA42DA1465FBE9474C0 /* ci_nanovg.cpp */,
-				45B309A0EBB045F89A5CD9DF /* ci_nanovg_gl.cpp */,
-				788BC0561D434BBCBA10E726 /* SvgRenderer.cpp */,
-			);
-			name = src;
-			sourceTree = "<group>";
-		};
-		0A3D0C9997B14BC09983F94D /* NanoVG */ = {
-			isa = PBXGroup;
-			children = (
-				FC1625E757134E088DE69B3E /* deps */,
-				BFD1A66EEDCB4C30AFEC8C7C /* include */,
-				654171FC48554C1EB167D506 /* src */,
-			);
-			name = NanoVG;
-			sourceTree = "<group>";
-		};
-		99692BD914FF149000DFFFFF /* Blocks */ = {
-			isa = PBXGroup;
-			children = (
-				0A3D0C9997B14BC09983F94D /* NanoVG */,
-			);
-			name = Blocks;
-			sourceTree = "<group>";
-		};
-		99692BD914FF149000D0A05F /* Headers */ = {
-			isa = PBXGroup;
-			children = (
-				9C8346E536E44435A9A812FD /* Resources.h */,
-				24194F6295AA49FE81BC4ADD /* RenderToTexture_Prefix.pch */,
-			);
-			name = Headers;
-			sourceTree = "<group>";
-		};
 		00692BD914FF149000D0A05E /* Source */ = {
 			isa = PBXGroup;
 			children = (
@@ -248,6 +148,83 @@
 				568EF07821894D1C93D52417 /* Info.plist */,
 			);
 			name = Resources;
+			sourceTree = "<group>";
+		};
+		0A3D0C9997B14BC09983F94D /* NanoVG */ = {
+			isa = PBXGroup;
+			children = (
+				FC1625E757134E088DE69B3E /* deps */,
+				BFD1A66EEDCB4C30AFEC8C7C /* include */,
+				654171FC48554C1EB167D506 /* src */,
+			);
+			name = NanoVG;
+			sourceTree = "<group>";
+		};
+		4AA5325281C649059D42688B /* nanovg */ = {
+			isa = PBXGroup;
+			children = (
+				52C06A2366E3408784FF37B9 /* src */,
+			);
+			name = nanovg;
+			sourceTree = "<group>";
+		};
+		52C06A2366E3408784FF37B9 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				4701242ABA77442D8AC961A8 /* fontstash.h */,
+				B28FA427C87B4DBA832BA2D6 /* nanovg.h */,
+				06CC4C73137C4F4A892E351D /* nanovg_gl.h */,
+				214F7A7D98144BF6A49EF2C1 /* nanovg_gl_utils.h */,
+				580CA6D2A3174679B160210C /* stb_image.h */,
+				DD6A528F507B4C2C982FC4B2 /* stb_truetype.h */,
+				565C0E679FE746CD9138D88C /* nanovg.c */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		654171FC48554C1EB167D506 /* src */ = {
+			isa = PBXGroup;
+			children = (
+				88377DA42DA1465FBE9474C0 /* ci_nanovg.cpp */,
+				45B309A0EBB045F89A5CD9DF /* ci_nanovg_gl.cpp */,
+				788BC0561D434BBCBA10E726 /* SvgRenderer.cpp */,
+			);
+			name = src;
+			sourceTree = "<group>";
+		};
+		99692BD914FF149000D0A05F /* Headers */ = {
+			isa = PBXGroup;
+			children = (
+				9C8346E536E44435A9A812FD /* Resources.h */,
+				24194F6295AA49FE81BC4ADD /* RenderToTexture_Prefix.pch */,
+			);
+			name = Headers;
+			sourceTree = "<group>";
+		};
+		99692BD914FF149000DFFFFF /* Blocks */ = {
+			isa = PBXGroup;
+			children = (
+				0A3D0C9997B14BC09983F94D /* NanoVG */,
+			);
+			name = Blocks;
+			sourceTree = "<group>";
+		};
+		BFD1A66EEDCB4C30AFEC8C7C /* include */ = {
+			isa = PBXGroup;
+			children = (
+				F6546D429BAB425EAEF2E135 /* ci_nanovg.hpp */,
+				5FFFE7AD2FD643CD918A9285 /* ci_nanovg_gl.hpp */,
+				574027D420DE43D894EAF7DC /* SvgRenderer.hpp */,
+			);
+			name = include;
+			sourceTree = "<group>";
+		};
+		FC1625E757134E088DE69B3E /* deps */ = {
+			isa = PBXGroup;
+			children = (
+				4AA5325281C649059D42688B /* nanovg */,
+			);
+			name = deps;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -275,6 +252,8 @@
 /* Begin PBXProject section */
 		00692BC614FF149000D0A05E /* Project object */ = {
 			isa = PBXProject;
+			attributes = {
+			};
 			buildConfigurationList = 00692BC914FF149000D0A05E /* Build configuration list for PBXProject "RenderToTexture" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
@@ -324,14 +303,18 @@
 		00692BF314FF149000D0A05E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "LaunchImage";
-				DEAD_CODE_STRIPPING = YES;
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = (
+					armv7,
+					arm64,
+				);
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CINDER_PATH = ../../../../..;
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
-				ARCHS = "armv7 arm64";
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -344,26 +327,26 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				CINDER_PATH = "../../../../..";
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
+				USER_HEADER_SEARCH_PATHS = ../include;
 			};
 			name = Debug;
 		};
 		00692BF414FF149000D0A05E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = "LaunchImage";
-				DEAD_CODE_STRIPPING = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
-				CLANG_CXX_LIBRARY = "libc++";
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD)";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CINDER_PATH = ../../../../..;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
+				CLANG_CXX_LIBRARY = "libc++";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				DEAD_CODE_STRIPPING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"NDEBUG=1",
@@ -373,14 +356,13 @@
 				GCC_WARN_ABOUT_MISSING_PROTOTYPES = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\"";
 				IPHONEOS_DEPLOYMENT_TARGET = 6.0;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				USER_HEADER_SEARCH_PATHS = ../include;
 				VALIDATE_PRODUCT = YES;
-				CINDER_PATH = "../../../../..";
-				HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/boost\"";
-				USER_HEADER_SEARCH_PATHS = "\"$(CINDER_PATH)/include\" ../include";
 			};
 			name = Release;
 		};
@@ -388,10 +370,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "RenderToTexture_Prefix.pch";
-				INFOPLIST_FILE = "Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
+				GCC_PREFIX_HEADER = RenderToTexture_Prefix.pch;
+				INFOPLIST_FILE = Info.plist;
 				"OTHER_LDFLAGS[sdk=iphoneos*][arch=*]" = (
 					"\"$(CINDER_PATH)/lib/libcinder-iphone_d.a\"",
 					"-lz",
@@ -400,6 +380,8 @@
 					"\"$(CINDER_PATH)/lib/libcinder-iphone-sim_d.a\"",
 					"-lz",
 				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
 		};
@@ -407,10 +389,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "RenderToTexture_Prefix.pch";
-				INFOPLIST_FILE = "Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
+				GCC_PREFIX_HEADER = RenderToTexture_Prefix.pch;
+				INFOPLIST_FILE = Info.plist;
 				"OTHER_LDFLAGS[sdk=iphoneos*][arch=*]" = (
 					"\"$(CINDER_PATH)/lib/libcinder-iphone.a\"",
 					"-lz",
@@ -419,6 +399,8 @@
 					"\"$(CINDER_PATH)/lib/libcinder-iphone-sim.a\"",
 					"-lz",
 				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
The old header search path entry for the Boost submodule needed to be removed and the OS X projects needed to link to the IOKit framework. It appears as though Xcode now strictly enforces some sort of alphabetical ordering in the plist so there are a bunch of changes it made silently by opening the project that are just property reorders :0\

The RTT iOS sample may need some attention, it doesn't seem to be drawing anything in the simulator.